### PR TITLE
chore: add default values for network and tokenType parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ const project = await client.projects.create({
   steps: 20, 
   guidance: 7.5, 
   numberOfImages: 1,
-  outputFormat: 'jpg' // Can be 'png' or 'jpg', defaults to 'png'
+  outputFormat: 'jpg', // Can be 'png' or 'jpg', defaults to 'png'
+  tokenType: 'spark', // 'sogni' or 'spark'
+  network: 'fast' // 'fast' or 'relaxed'
 });
 ```
 **Note:** Full project parameter list can be found in [ProjectParams](https://sdk-docs.sogni.ai/interfaces/ProjectParams.html) docs.
@@ -102,7 +104,9 @@ const project = await client.projects.create({
   negativePrompt:
     'malformation, bad anatomy, bad hands, missing fingers, cropped, low quality, bad quality, jpeg artifacts, watermark',
   stylePrompt: 'anime',
-  numberOfImages: 4
+  numberOfImages: 4,
+  tokenType: 'spark', // 'sogni' or 'spark'
+  network: 'fast' // 'fast' or 'relaxed'
 });
 
 project.on('progress', (progress) => {
@@ -125,7 +129,9 @@ const project = await client.projects.create({
   negativePrompt:
     'malformation, bad anatomy, bad hands, missing fingers, cropped, low quality, bad quality, jpeg artifacts, watermark',
   stylePrompt: 'anime',
-  numberOfImages: 4
+  numberOfImages: 4,
+  tokenType: 'spark', // 'sogni' or 'spark'
+  network: 'fast' // 'fast' or 'relaxed'
 });
 
 // Fired when one of project jobs completed, you can get the resultUrl from the job

--- a/examples/event_driven.js
+++ b/examples/event_driven.js
@@ -33,7 +33,9 @@ getClient()
       stylePrompt: 'anime',
       numberOfPreviews: 2,
       numberOfImages: 2,
-      outputFormat: 'png' // Can be 'png' or 'jpg', defaults to 'png'
+      outputFormat: 'png', // Can be 'png' or 'jpg', defaults to 'png'
+      tokenType: 'spark', // 'sogni' or 'spark'
+      network: 'fast' // 'fast' or 'relaxed'
     });
 
     // Receive project completion percentage in real-time

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -8,7 +8,8 @@ const APP_ID = 'your-app-id';
 
 let client;
 SogniClient.createInstance({
-  appId: APP_ID
+  appId: APP_ID,
+  network: 'fast' // 'fast' or 'relaxed'
 })
   .then(async (clientInstance) => {
     client = clientInstance;
@@ -42,7 +43,9 @@ app.post('/api/generate', async function (req, res) {
       stylePrompt: style,
       steps: 4,
       guidance: 1,
-      numberOfImages: 1
+      numberOfImages: 1,
+      tokenType: 'spark', // 'sogni' or 'spark'
+      network: 'fast' // 'fast' or 'relaxed'
     });
     const imageUrls = await project.waitForCompletion();
     res.send({ url: imageUrls[0] });

--- a/examples/promise_based.mjs
+++ b/examples/promise_based.mjs
@@ -27,7 +27,7 @@ async function downloadImage(url) {
 
 const client = await SogniClient.createInstance({
   appId: `${USERNAME}-image-generator`,
-  network: 'relaxed' // or 'fast' for faster but more expensive processing
+  network: 'fast' // or 'relaxed' for slower but cheaper processing
 });
 
 await client.account.login(USERNAME, PASSWORD);
@@ -46,7 +46,9 @@ const project = await client.projects.create({
     'malformation, bad anatomy, bad hands, missing fingers, cropped, low quality, bad quality, jpeg artifacts, watermark',
   stylePrompt: 'anime',
   numberOfImages: 4,
-  outputFormat: 'jpg' // Can be 'png' or 'jpg', defaults to 'png'
+  outputFormat: 'jpg', // Can be 'png' or 'jpg', defaults to 'png'
+  tokenType: 'spark', // 'sogni' or 'spark'
+  network: 'fast' // 'fast' or 'relaxed'
 });
 
 project.on('progress', (progress) => {

--- a/src/Projects/index.ts
+++ b/src/Projects/index.ts
@@ -503,7 +503,7 @@ class ProjectsApi extends ApiGroup<ProjectApiEvents> {
    * Estimate project cost
    */
   async estimateCost({
-    network,
+    network = 'fast',
     tokenType,
     model,
     imageCount,

--- a/src/Projects/types/index.ts
+++ b/src/Projects/types/index.ts
@@ -133,6 +133,7 @@ export interface ProjectParams {
   /**
    * Select which tokens to use for the project.
    * If not specified, the Sogni token will be used.
+   * @default 'sogni'
    */
   tokenType?: TokenType;
   /**
@@ -153,10 +154,12 @@ export type ImageUrlParams = {
 export interface EstimateRequest {
   /**
    * Network to use. Can be 'fast' or 'relaxed'
+   * @default 'fast'
    */
-  network: SupernetType;
+  network?: SupernetType;
   /**
    * Token type
+   * @default 'sogni'
    */
   tokenType?: TokenType;
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,9 @@ export interface SogniClientConfig {
   disableSocket?: boolean;
   /**
    * Which network to use after logging in. Can be 'fast' or 'relaxed'
+   * @default 'fast'
    */
-  network: SupernetType;
+  network?: SupernetType;
   /**
    * Logger to use. If not provided, a default console logger will be used
    */


### PR DESCRIPTION
- Make SogniClientConfig.network optional with default 'fast'
- Make EstimateRequest.network optional with default 'fast'
- Add proper @default documentation for tokenType ('sogni')
- Update estimateCost method to handle optional network parameter
- Update all examples and README to use tokenType: 'spark' and network: 'fast'
- Maintain backward compatibility - no breaking changes

This improves developer experience by providing sensible defaults while maintaining full control when explicitly specified.