### PR TITLE
feat: offline project recovery on socket reconnection

### DIFF
--- a/src/ApiClient/WebSocketClient/events.ts
+++ b/src/ApiClient/WebSocketClient/events.ts
@@ -2,6 +2,85 @@ import { SupernetType } from './types';
 import { Balances } from '../../Account/types';
 import { LLMJobCost, LLMModelInfo, ToolCallDelta } from '../../Chat/types';
 
+export interface RecoveredWorkerJob {
+  id: string;
+  SID: number;
+  imgID: string;
+  worker: {
+    id: string;
+    address: string;
+    username: string;
+    nftTokenId?: string;
+  };
+  createTime: number;
+  startTime: number | null;
+  updateTime: number;
+  actualStartTime: number | null;
+  endTime: number | null;
+  status: string;
+  reason: string;
+  performedSteps: number;
+  triggeredNSFWFilter: boolean;
+  seedUsed: number;
+  costActual: Record<string, string>;
+  network: string;
+  txId: string | null;
+  jobType: string;
+  tokenType: string;
+  isTest: boolean;
+  speedVsBaseline?: number;
+  timings?: Record<string, unknown>;
+  modelType?: 'video';
+  videoFrames?: number;
+  videoFps?: number;
+  width?: number;
+  height?: number;
+  provider?: string;
+}
+
+export interface RecoveredProject {
+  id: string;
+  SID: number;
+  jobType: string;
+  model: {
+    id: string;
+    SID: number;
+    name: string;
+    type: string;
+  };
+  imageCount: number;
+  stepCount: number;
+  previewCount: number;
+  hasGuideImage: boolean;
+  hasContextImage1: boolean;
+  hasContextImage2: boolean;
+  denoiseStrength: string;
+  controlNetId: string | null;
+  costEstimate: Record<string, unknown>;
+  costActual: Record<string, unknown>;
+  createTime: number;
+  updateTime: number;
+  endTime: number | null;
+  status: string;
+  reason: string | null;
+  network: string;
+  txId: string | null;
+  sizePreset: string;
+  width: number;
+  height: number;
+  jobCountCompletedByState: Record<string, number>;
+  isTest: boolean;
+  tokenType: string;
+  clientRequestData?: string;
+  workerJobs?: RecoveredWorkerJob[];
+  completedWorkerJobs?: RecoveredWorkerJob[];
+  premium?: Record<string, unknown>;
+  modelType?: 'video';
+  videoFrames?: number;
+  videoFps?: number;
+  provider?: string;
+}
+
 export interface AuthenticatedData {
   id: string;
   clientType: 'artist' | 'worker';
@@ -25,8 +104,8 @@ export interface AuthenticatedData {
       net: string;
     };
   };
-  activeProjects: [];
-  unclaimedCompletedProjects: [];
+  activeProjects: RecoveredProject[];
+  unclaimedCompletedProjects: RecoveredProject[];
   isMainnet: boolean;
   accountWasMigrated: boolean;
   hasUnclaimedAirdrop: boolean;

--- a/src/Projects/Project.ts
+++ b/src/Projects/Project.ts
@@ -231,6 +231,31 @@ class Project extends DataEntity<ProjectData, ProjectEventMap> {
   }
 
   /**
+   * Pause the timeout interval during socket disconnect to prevent
+   * premature project failure while offline.
+   * @internal
+   */
+  _pauseTimeout() {
+    if (this._timeout) {
+      clearInterval(this._timeout);
+      this._timeout = null;
+    }
+  }
+
+  /**
+   * Resume the timeout interval after socket reconnect.
+   * Resets lastUpdated to prevent immediate timeout.
+   * @internal
+   */
+  _resumeTimeout() {
+    if (!this._timeout && !this.finished) {
+      this.lastUpdated = new Date();
+      this._failedSyncAttempts = 0;
+      this._timeout = setInterval(this._checkForTimeout.bind(this), PROJECT_TIMEOUT);
+    }
+  }
+
+  /**
    * This is internal method to add a job to the project. Do not call this directly.
    * @internal
    * @param data

--- a/src/Projects/index.ts
+++ b/src/Projects/index.ts
@@ -20,9 +20,13 @@ import {
   JobProgressData,
   JobResultData,
   JobStateData,
-  SocketEventMap
+  SocketEventMap,
+  AuthenticatedData,
+  RecoveredProject,
+  RecoveredWorkerJob,
 } from '../ApiClient/WebSocketClient/events';
-import Project from './Project';
+import { CompletedRecoveredProject } from './types/events';
+import Project, { ProjectStatus } from './Project';
 import createJobRequestMessage from './createJobRequestMessage';
 import { ApiError, ApiResponse } from '../ApiClient';
 import { EstimationResponse } from './types/EstimationResponse';
@@ -205,6 +209,7 @@ class ProjectsApi extends ApiGroup<ProjectApiEvents> {
     // Listen to project and job events and update project and job instances
     this.on('project', this.handleProjectEvent.bind(this));
     this.on('job', this.handleJobEvent.bind(this));
+    this.client.socket.on('authenticated', this.handleSocketAuthenticated.bind(this));
   }
 
   /**
@@ -545,8 +550,210 @@ class ProjectsApi extends ApiGroup<ProjectApiEvents> {
   private handleServerDisconnected() {
     this._availableModels = [];
     this.emit('availableModels', this._availableModels);
-    this.projects.forEach((p) => {
-      p._update({ status: 'failed', error: { code: 0, message: 'Server disconnected' } });
+    // Do NOT fail tracked projects — they may recover on reconnect.
+    // Pause timeout intervals so they don't force-fail during disconnect.
+    this.projects.forEach((p) => p._pauseTimeout());
+  }
+
+  private async handleSocketAuthenticated(data: AuthenticatedData) {
+    const { activeProjects, unclaimedCompletedProjects } = data;
+    if (!activeProjects?.length && !unclaimedCompletedProjects?.length) return;
+
+    this.client.logger.info(
+      `[RECOVERY] Authenticated with ${activeProjects?.length || 0} active, ` +
+      `${unclaimedCompletedProjects?.length || 0} unclaimed completed projects`
+    );
+
+    // Deduplicate: a project could theoretically appear in both arrays
+    const seenIds = new Set<string>();
+
+    // Resume timeouts on all existing tracked projects
+    this.projects.forEach((p) => p._resumeTimeout());
+
+    // --- Active projects ---
+    const unmatchedActive: RecoveredProject[] = [];
+    for (const recovered of (activeProjects || [])) {
+      if (recovered.jobType === 'llm') continue;
+      seenIds.add(recovered.id);
+
+      const tracked = this.projects.find((p) => p.id === recovered.id);
+      if (tracked) {
+        if (tracked.status === 'failed' || tracked.status === 'pending') {
+          const statusMap: Record<string, ProjectStatus> = {
+            queued: 'queued',
+            active: 'queued',
+            assigned: 'processing',
+            progress: 'processing',
+          };
+          const mappedStatus = statusMap[recovered.status] || 'processing';
+          tracked._update({ status: mappedStatus, error: undefined });
+        }
+      } else {
+        const rehydrated = this._rehydrateProject(recovered);
+        this.projects.push(rehydrated);
+        unmatchedActive.push(recovered);
+      }
+    }
+
+    // --- Completed projects ---
+    const unmatchedCompleted: CompletedRecoveredProject[] = [];
+    for (const recovered of (unclaimedCompletedProjects || [])) {
+      if (recovered.jobType === 'llm') continue;
+      if (seenIds.has(recovered.id)) continue;
+
+      const tracked = this.projects.find((p) => p.id === recovered.id);
+      if (tracked) {
+        await this._resolveAndCompleteTrackedProject(tracked, recovered);
+      } else {
+        const resultUrls = await this._resolveRecoveredProjectUrls(recovered);
+        unmatchedCompleted.push({ ...recovered, resultUrls });
+      }
+    }
+
+    if (unmatchedActive.length > 0) {
+      this.client.logger.info(`[RECOVERY] Emitting ${unmatchedActive.length} active recovered projects`);
+      this.emit('activeProjectsRecovered', unmatchedActive);
+    }
+    if (unmatchedCompleted.length > 0) {
+      this.client.logger.info(`[RECOVERY] Emitting ${unmatchedCompleted.length} completed recovered projects`);
+      this.emit('completedProjectsRecovered', unmatchedCompleted);
+    }
+  }
+
+  private _rehydrateProject(recovered: RecoveredProject): Project {
+    const mediaType = recovered.model?.type === 'video' ? 'video'
+      : recovered.model?.type === 'music' ? 'audio'
+      : 'image';
+
+    const project = new Project(
+      {
+        type: mediaType,
+        modelId: recovered.model.id,
+        positivePrompt: '',
+        numberOfMedia: recovered.imageCount,
+        steps: recovered.stepCount,
+      } as any,
+      { api: this, logger: this.client.logger }
+    );
+
+    // Override the auto-generated UUID with the server's actual project ID
+    (project as any).data.id = recovered.id;
+
+    for (const wj of (recovered.workerJobs || [])) {
+      project._addJob({
+        id: wj.imgID,
+        projectId: recovered.id,
+        status: wj.status === 'jobStarted' ? 'processing'
+          : wj.status === 'assigned' ? 'initiating'
+          : 'pending',
+        step: wj.performedSteps || 0,
+        stepCount: recovered.stepCount,
+        workerName: wj.worker?.username,
+      });
+    }
+
+    const statusMap: Record<string, ProjectStatus> = {
+      queued: 'queued', active: 'queued',
+      assigned: 'processing', progress: 'processing',
+    };
+    project._update({
+      status: statusMap[recovered.status] || 'processing'
+    });
+
+    return project;
+  }
+
+  private async _resolveAndCompleteTrackedProject(
+    tracked: Project,
+    recovered: RecoveredProject
+  ) {
+    for (const wj of (recovered.completedWorkerJobs || [])) {
+      let job = tracked.job(wj.imgID);
+      if (!job) {
+        job = tracked._addJob({
+          id: wj.imgID,
+          projectId: tracked.id,
+          status: 'pending',
+          step: 0,
+          stepCount: recovered.stepCount
+        });
+      }
+      if (job.finished) continue;
+
+      let resultUrl: string | null = null;
+      if (!wj.triggeredNSFWFilter) {
+        try {
+          resultUrl = await this._downloadUrlForRecoveredJob(recovered, wj);
+        } catch (e) {
+          this.client.logger.error('Failed to resolve URL for recovered job', e);
+        }
+      }
+      job._update({
+        status: wj.triggeredNSFWFilter ? 'failed' : 'completed',
+        step: wj.performedSteps,
+        seed: wj.seedUsed,
+        resultUrl,
+        isNSFW: wj.triggeredNSFWFilter,
+        workerName: wj.worker?.username
+      });
+    }
+    // Only mark completed if all expected jobs are accounted for
+    const completedJobCount = tracked.jobs.filter((j) => j.finished).length;
+    if (completedJobCount >= recovered.imageCount) {
+      tracked._update({ status: 'completed' });
+    }
+  }
+
+  private async _resolveRecoveredProjectUrls(
+    recovered: RecoveredProject
+  ): Promise<string[]> {
+    const urls: string[] = [];
+    const isVideo = recovered.model?.type === 'video';
+    const isAudio = recovered.model?.type === 'music';
+    const isMedia = isVideo || isAudio;
+
+    for (const wj of (recovered.completedWorkerJobs || [])) {
+      if (wj.triggeredNSFWFilter) continue;
+      try {
+        let url: string;
+        if (isMedia) {
+          url = await this.mediaDownloadUrl({
+            jobId: recovered.id,
+            id: wj.imgID,
+            type: 'complete'
+          });
+        } else {
+          url = await this.downloadUrl({
+            jobId: recovered.id,
+            imageId: wj.imgID,
+            type: 'complete'
+          });
+        }
+        urls.push(url);
+      } catch (e) {
+        this.client.logger.error('Failed to resolve URL for recovered project', e);
+      }
+    }
+    return urls;
+  }
+
+  private async _downloadUrlForRecoveredJob(
+    recovered: RecoveredProject,
+    wj: RecoveredWorkerJob
+  ): Promise<string> {
+    const isVideo = recovered.model?.type === 'video';
+    const isAudio = recovered.model?.type === 'music';
+    if (isVideo || isAudio) {
+      return this.mediaDownloadUrl({
+        jobId: recovered.id,
+        id: wj.imgID,
+        type: 'complete'
+      });
+    }
+    return this.downloadUrl({
+      jobId: recovered.id,
+      imageId: wj.imgID,
+      type: 'complete'
     });
   }
 

--- a/src/Projects/types/events.ts
+++ b/src/Projects/types/events.ts
@@ -1,5 +1,6 @@
 import { AvailableModel } from './index';
 import ErrorData from '../../types/ErrorData';
+import { RecoveredProject } from '../../ApiClient/WebSocketClient/events';
 
 export interface ProjectEventBase {
   projectId: string;
@@ -85,8 +86,15 @@ export type JobEvent =
   | JobCompleted
   | JobError;
 
+export interface CompletedRecoveredProject extends RecoveredProject {
+  /** Resolved download URLs for each completed worker job */
+  resultUrls: string[];
+}
+
 export interface ProjectApiEvents {
   availableModels: AvailableModel[];
   project: ProjectEvent;
   job: JobEvent;
+  activeProjectsRecovered: RecoveredProject[];
+  completedProjectsRecovered: CompletedRecoveredProject[];
 }


### PR DESCRIPTION
## Summary

- Process `activeProjects` and `unclaimedCompletedProjects` from the `authenticated` socket event to recover AI generation projects after temporary disconnects
- Stop immediately failing tracked projects on disconnect — pause timeouts instead, allowing seamless recovery on reconnect
- Rehydrate unmatched projects into the SDK's tracked list so normal `jobState`/`jobResult` events flow to them
- Emit separate `activeProjectsRecovered` and `completedProjectsRecovered` events for consumer-side routing (e.g., sogni-chat routes results to correct chat sessions)

## Changes

| File | Change |
|------|--------|
| `src/ApiClient/WebSocketClient/events.ts` | Add `RecoveredProject`, `RecoveredWorkerJob` types; fix `AuthenticatedData` array types |
| `src/Projects/types/events.ts` | Add `CompletedRecoveredProject` interface and recovery events to `ProjectApiEvents` |
| `src/Projects/Project.ts` | Add `_pauseTimeout()` / `_resumeTimeout()` internal methods |
| `src/Projects/index.ts` | Fix `handleServerDisconnected`; add `handleSocketAuthenticated` + 4 helper methods |

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Test normal project flow still works (create project, receive events, complete)
- [ ] Test short disconnect (<2s): projects resume seamlessly, no recovery events
- [ ] Test longer disconnect with page refresh: `completedProjectsRecovered` event fires with resolved URLs
- [ ] Verify LLM projects in `activeProjects` are skipped (no crash)
- [ ] Verify projects from other apps (no consumer listener) are emitted but don't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)