### PR TITLE
fix(subscription): align Unlimited entitlement SDK surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,36 @@ sogni.client.on('disconnected', ({ code, reason }) => {
 });
 ```
 
+### Subscription entitlements
+
+The account API exposes the public subscription plan catalog and the current wallet's entitlement snapshot:
+
+```typescript
+const plans = await sogni.account.getSubscriptionPlans();
+
+const subscription = await sogni.account.refreshSubscription();
+if (sogni.account.currentAccount.isUnlimited) {
+  console.log('Unlimited tier:', subscription.tier);
+}
+```
+
+`currentAccount.isUnlimited` is `true` when the latest entitlement snapshot has `active: true` and `tier` is either `unlimited` or `unlimited_pro`. The server keeps `active` true for entitled states such as trials, grace periods, and cancel-at-period-end windows until access actually ends. Period dates are ISO timestamp strings.
+
+Unlimited fair-use accounting and enforcement are handled dynamically by the Sogni socket service. The SDK does not expose per-period usage counters or plan limit tables for clients to store or display as durable user-facing limits.
+
+To start Stripe checkout, use a plan's `planId` (`unlimited` or `unlimited_pro`) and `term` (`monthly` or `annual`). Checkout and portal sessions require user authentication; API-key auth is rejected for those browser redirect operations.
+
+```typescript
+const { url } = await sogni.account.createSubscriptionCheckout('unlimited_pro', 'annual', {
+  redirectType: 'web',
+  appSource: 'my-integration'
+});
+window.location.href = url;
+
+const portal = await sogni.account.createSubscriptionPortalSession();
+window.location.href = portal.url;
+```
+
 ## Image Generation
 
 Sogni supports a wide range of models for image generation. You can find a list of available models in

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -175,6 +175,44 @@ await sogni.account.refreshBalance();
 console.log(sogni.account.currentAccount.balance);
 ```
 
+SUBSCRIPTION ENTITLEMENTS:
+
+```javascript
+// Public plan catalog. Each entry is one plan/tier + billing term.
+const plans = await sogni.account.getSubscriptionPlans();
+// [{ planId, tier, term, interval, priceUsd, displayName }]
+
+// Current wallet entitlement snapshot. Also updates currentAccount.subscription.
+const subscription = await sogni.account.refreshSubscription();
+if (sogni.account.currentAccount.isUnlimited) {
+  console.log('Unlimited tier:', subscription.tier);
+}
+```
+
+`SubscriptionEntitlementSnapshot.status` values are `none`, `trialing`,
+`active`, `grace_period`, `past_due`, `paused`, `cancel_at_period_end`,
+`canceled`, `expired`, and `refunded`. Period dates are ISO timestamp strings.
+`currentAccount.isUnlimited` is true when the latest snapshot has `active:true`
+and `tier` is `unlimited` or `unlimited_pro`; the server keeps `active:true`
+through trials, grace periods, and cancel-at-period-end windows until access
+actually ends.
+
+Unlimited fair-use accounting and enforcement are dynamic and server-side in
+the socket service. The SDK does not expose per-period usage counters or plan
+limit tables for clients to store or display as fixed user-facing limits.
+
+Stripe checkout uses catalog plan IDs (`unlimited` or `unlimited_pro`) plus a
+term (`monthly` or `annual`). Checkout and portal sessions require user
+authentication; API-key auth is rejected for those browser redirect operations.
+
+```javascript
+const { url } = await sogni.account.createSubscriptionCheckout('unlimited_pro', 'annual', {
+  redirectType: 'web',
+  appSource: 'my-integration'
+});
+const portal = await sogni.account.createSubscriptionPortalSession();
+```
+
 `checkAuth()` is only for cookie-auth browser flows on permitted Sogni domains. API-key auth auto-authenticates during `createInstance()`. Username/password auth uses `sogni.account.login()`. Token auth can be resumed with `sogni.setTokens()`.
 
 NETWORK TYPES:

--- a/llms.txt
+++ b/llms.txt
@@ -110,6 +110,30 @@ await sogni.account.login(username, password);
 - **API key**: Pass `apiKey` to `createInstance()`. Auto-authenticates via WebSocket. No `login()` call needed. Most REST API calls (balance, profile, etc.) available. Sensitive operations (withdrawals, staking, 2FA) not available.
 - **Username/password**: Call `sogni.account.login()` after creating instance. Full REST API access.
 
+### Subscription Entitlements
+
+```javascript
+const plans = await sogni.account.getSubscriptionPlans(); // [{ planId, tier, term, interval, priceUsd, displayName }]
+const subscription = await sogni.account.refreshSubscription(); // unwraps data.subscription
+const isUnlimited = sogni.account.currentAccount.isUnlimited; // active && tier is unlimited/unlimited_pro
+```
+
+`subscription.status` is one of `none`, `trialing`, `active`, `grace_period`, `past_due`, `paused`, `cancel_at_period_end`, `canceled`, `expired`, or `refunded`. Period dates are ISO strings. `isUnlimited` trusts the server's `active` entitlement flag, so trialing/grace/cancel-at-period-end snapshots remain entitled until the server returns `active:false`.
+
+Unlimited fair-use accounting and enforcement are dynamic and server-side in the socket service. The SDK does not expose per-period usage counters or plan limit tables for clients to store or display as fixed user-facing limits.
+
+Stripe checkout uses catalog plan IDs, not monthly/annual suffixed IDs:
+
+```javascript
+const { url } = await sogni.account.createSubscriptionCheckout('unlimited_pro', 'annual', {
+  redirectType: 'web',
+  appSource: 'my-integration'
+});
+const portal = await sogni.account.createSubscriptionPortalSession();
+```
+
+Checkout and portal sessions require user authentication; API-key auth is rejected for those redirect operations.
+
 ### Network Types
 
 - `fast` - High-end GPUs, faster, more expensive. **Required for video.**

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prepublishOnly": "npm run build",
     "build": "npm run clean && npm run codegen && tsc --project tsconfig.json && tsc --project tsconfig.esm.json && node scripts/write-dist-esm-package-json.mjs",
     "test:chat-routing": "npm run build && node scripts/check-chat-model-routing.cjs",
+    "test:subscription-api": "npm run build && node scripts/check-subscription-api.cjs",
     "test:workflow-template-envelope": "npm run build && node scripts/check-workflow-template-envelope.cjs",
     "watch": "npm run clean && npm run codegen && tsc --watch --project tsconfig.json",
     "watch:esm": "npm run codegen && tsc --watch --project tsconfig.esm.json",

--- a/scripts/check-subscription-api.cjs
+++ b/scripts/check-subscription-api.cjs
@@ -1,294 +1,250 @@
 /**
- * Unit tests for the subscription API surface added in this branch.
+ * Smoke tests for the subscription SDK surface.
  *
- * Verifies:
- *   - AccountApi methods call the correct endpoints with the right HTTP
- *     method and body.
- *   - Responses are unwrapped from the `{ status, data }` envelope.
- *   - getSubscriptionStatus() propagates the snapshot to currentAccount.
- *   - CurrentAccount.subscription accessor and isUnlimited getter behave
- *     correctly across the full status/tier matrix.
- *   - _clear() resets subscription to undefined.
- *   - refreshSubscription() is a convenience alias that also updates
- *     currentAccount.
- *
- * Runs against the compiled dist/ output so it doubles as a build-smoke
- * test for the subscription types being present at the public export.
+ * Runs against compiled `dist/` output so it also verifies public declaration
+ * files and CommonJS imports after a real build.
  */
 
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
-// ─── Load compiled artefacts ─────────────────────────────────────────────────
-
-const AccountApi   = require('../dist/Account/index.js').default;
+const AccountApi = require('../dist/Account/index.js').default;
 const CurrentAccount = require('../dist/Account/CurrentAccount.js').default;
 
-// ─── Stub infrastructure ─────────────────────────────────────────────────────
-
 class StubAuth {
-  constructor() { this.isAuthenticated = true; }
-  async authenticateRequest(init) { return init ?? {}; }
-  clear() { this.isAuthenticated = false; }
-  on()  {}
+  constructor() {
+    this.isAuthenticated = true;
+  }
+
+  async authenticateRequest(init) {
+    return init ?? {};
+  }
+
+  clear() {
+    this.isAuthenticated = false;
+  }
+
+  on() {}
   off() {}
 }
 
 class StubSocket {
-  get isConnected() { return false; }
-  get supernetType() { return 'fast'; }
-  on()  {}
+  get isConnected() {
+    return false;
+  }
+
+  get supernetType() {
+    return 'fast';
+  }
+
+  on() {}
   off() {}
 }
 
 function makeStubClient() {
-  const auth   = new StubAuth();
+  const auth = new StubAuth();
   const socket = new StubSocket();
-
-  // Minimal RestClient stub: captures last call, resolves with `_nextPayload`.
   const rest = {
     baseUrl: 'https://api.example.test',
     _lastCall: null,
     _nextPayload: null,
-    async get(path, _query) {
-      this._lastCall = { method: 'GET', path, body: null };
+    async get(endpoint, query) {
+      this._lastCall = { method: 'GET', endpoint, query, body: null };
       return this._nextPayload;
     },
-    async post(path, body) {
-      this._lastCall = { method: 'POST', path, body };
+    async post(endpoint, body) {
+      this._lastCall = { method: 'POST', endpoint, query: null, body };
       return this._nextPayload;
     }
   };
 
-  const client = {
+  return {
     auth,
     socket,
     rest,
-    on()  {},
+    appId: 'subscription-test',
+    appSource: 'sdk-test',
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    on() {},
     off() {}
   };
-
-  return client;
 }
-
-const STUB_EIP712 = {};
 
 function makeApi() {
   const client = makeStubClient();
-  const config = { client, eip712: STUB_EIP712 };
-  const api = new AccountApi(config);
+  const api = new AccountApi({ client, eip712: {} });
   return { api, client };
 }
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function apiResponse(data) {
   return { status: 'success', data };
 }
 
-// ─── Tests ───────────────────────────────────────────────────────────────────
-
 async function run() {
-
-  // ── 1. getSubscriptionStatus ──────────────────────────────────────────────
-
   {
     const { api, client } = makeApi();
     const snapshot = {
       active: true,
       status: 'active',
       tier: 'unlimited',
-      planId: 'unlimited_monthly',
       provider: 'stripe',
-      currentPeriodStart: 1700000000,
-      currentPeriodEnd:   1702678400,
+      currentPeriodStart: '2026-06-01T00:00:00.000Z',
+      currentPeriodEnd: '2026-07-01T00:00:00.000Z',
       cancelAtPeriodEnd: false
     };
-    client.rest._nextPayload = apiResponse(snapshot);
+    client.rest._nextPayload = apiResponse({ subscription: snapshot });
 
     const result = await api.getSubscriptionStatus();
 
     assert.equal(
-      client.rest._lastCall.path,
+      client.rest._lastCall.endpoint,
       '/v1/subscriptions/status',
       'getSubscriptionStatus() must GET /v1/subscriptions/status'
     );
     assert.equal(client.rest._lastCall.method, 'GET');
-    assert.deepEqual(result, snapshot, 'getSubscriptionStatus() must return unwrapped snapshot');
-
-    // Snapshot propagates to currentAccount
+    assert.deepEqual(result, snapshot, 'getSubscriptionStatus() must unwrap data.subscription');
     assert.deepEqual(
       api.currentAccount.subscription,
       snapshot,
       'getSubscriptionStatus() must update currentAccount.subscription'
     );
-
-    // isUnlimited gate
-    assert.equal(
-      api.currentAccount.isUnlimited,
-      true,
-      'isUnlimited must be true for active unlimited subscription'
-    );
+    assert.equal(api.currentAccount.isUnlimited, true);
   }
-
-  // ── 2. getSubscriptionPlans ───────────────────────────────────────────────
 
   {
     const { api, client } = makeApi();
     const plans = [
       {
-        planId: 'unlimited_monthly',
-        name: 'Unlimited Monthly',
-        term: 'monthly',
-        currency: 'usd',
-        price: 999,
-        displayPrice: '$9.99/mo',
+        planId: 'unlimited',
         tier: 'unlimited',
-        trialAvailable: true,
-        trialDays: 7,
-        features: ['Unlimited images', 'Unlimited videos']
+        term: 'monthly',
+        interval: 'month',
+        priceUsd: 20,
+        displayName: 'Unlimited (Monthly)'
+      },
+      {
+        planId: 'unlimited_pro',
+        tier: 'unlimited_pro',
+        term: 'annual',
+        interval: 'year',
+        priceUsd: 498,
+        displayName: 'Unlimited Pro (Annual)'
       }
     ];
-    client.rest._nextPayload = apiResponse(plans);
+    client.rest._nextPayload = apiResponse({ plans });
 
     const result = await api.getSubscriptionPlans();
 
     assert.equal(
-      client.rest._lastCall.path,
+      client.rest._lastCall.endpoint,
       '/v1/subscriptions/plans',
       'getSubscriptionPlans() must GET /v1/subscriptions/plans'
     );
-    assert.equal(client.rest._lastCall.method, 'GET');
-    assert.deepEqual(result, plans, 'getSubscriptionPlans() must return unwrapped plan array');
-    assert.equal(result.length, 1);
-    assert.equal(result[0].planId, 'unlimited_monthly');
+    assert.deepEqual(result, plans, 'getSubscriptionPlans() must unwrap data.plans');
+    assert.equal(result[1].planId, 'unlimited_pro');
+    assert.equal(result[1].priceUsd, 498);
   }
-
-  // ── 3. getSubscriptionUsage ───────────────────────────────────────────────
 
   {
     const { api, client } = makeApi();
-    const usage = {
-      imagesGenerated: 42,
-      videosGenerated: 7,
-      tokensUsed: 18500,
-      periodStart: 1700000000,
-      periodEnd:   1702678400
-    };
-    client.rest._nextPayload = apiResponse(usage);
+    client.rest._nextPayload = apiResponse({
+      message: 'Stripe subscription session created',
+      url: 'https://checkout.stripe.com/pay/cs_test_unlimited'
+    });
 
-    const result = await api.getSubscriptionUsage();
+    const result = await api.createSubscriptionCheckout('unlimited', 'monthly');
 
     assert.equal(
-      client.rest._lastCall.path,
-      '/v1/subscriptions/usage',
-      'getSubscriptionUsage() must GET /v1/subscriptions/usage'
-    );
-    assert.equal(client.rest._lastCall.method, 'GET');
-    assert.deepEqual(result, usage, 'getSubscriptionUsage() must return unwrapped usage object');
-  }
-
-  // ── 4. createSubscriptionCheckout ────────────────────────────────────────
-
-  {
-    const { api, client } = makeApi();
-    client.rest._nextPayload = apiResponse({ url: 'https://checkout.stripe.com/pay/cs_test_abc123' });
-
-    const result = await api.createSubscriptionCheckout('unlimited_monthly', 'monthly');
-
-    assert.equal(
-      client.rest._lastCall.path,
+      client.rest._lastCall.endpoint,
       '/v1/iap/stripe/subscribe',
       'createSubscriptionCheckout() must POST /v1/iap/stripe/subscribe'
     );
-    assert.equal(client.rest._lastCall.method, 'POST');
     assert.deepEqual(
       client.rest._lastCall.body,
-      { planId: 'unlimited_monthly', term: 'monthly' },
-      'createSubscriptionCheckout() must send planId + term in body'
+      { planId: 'unlimited', term: 'monthly', redirectType: 'web' },
+      'createSubscriptionCheckout() must default redirectType to web'
     );
-    assert.equal(result.url, 'https://checkout.stripe.com/pay/cs_test_abc123');
+    assert.equal(result.url, 'https://checkout.stripe.com/pay/cs_test_unlimited');
 
-    // annual term
-    client.rest._nextPayload = apiResponse({ url: 'https://checkout.stripe.com/pay/cs_test_annual' });
-    await api.createSubscriptionCheckout('unlimited_annual', 'annual');
-    assert.deepEqual(
-      client.rest._lastCall.body,
-      { planId: 'unlimited_annual', term: 'annual' }
-    );
+    client.rest._nextPayload = apiResponse({ url: 'https://checkout.stripe.com/pay/cs_test_pro' });
+    await api.createSubscriptionCheckout('unlimited_pro', 'annual', {
+      redirectType: 'photobooth',
+      appSource: 'sogni-photobooth'
+    });
+    assert.deepEqual(client.rest._lastCall.body, {
+      planId: 'unlimited_pro',
+      term: 'annual',
+      redirectType: 'photobooth',
+      appSource: 'sogni-photobooth'
+    });
   }
-
-  // ── 5. createSubscriptionPortalSession ───────────────────────────────────
 
   {
     const { api, client } = makeApi();
-    client.rest._nextPayload = apiResponse({ url: 'https://billing.stripe.com/session/bps_test_xyz' });
+    client.rest._nextPayload = apiResponse({ url: 'https://billing.stripe.com/session/bps_test' });
 
     const result = await api.createSubscriptionPortalSession();
 
     assert.equal(
-      client.rest._lastCall.path,
+      client.rest._lastCall.endpoint,
       '/v1/subscriptions/stripe/portal',
       'createSubscriptionPortalSession() must POST /v1/subscriptions/stripe/portal'
     );
     assert.equal(client.rest._lastCall.method, 'POST');
-    assert.equal(result.url, 'https://billing.stripe.com/session/bps_test_xyz');
+    assert.deepEqual(client.rest._lastCall.body, {});
+    assert.equal(result.url, 'https://billing.stripe.com/session/bps_test');
   }
-
-  // ── 6. refreshSubscription (alias) ───────────────────────────────────────
 
   {
     const { api, client } = makeApi();
-    const snapshot = { active: true, status: 'trialing', tier: 'unlimited', planId: 'unlimited_monthly' };
-    client.rest._nextPayload = apiResponse(snapshot);
+    const snapshot = {
+      active: true,
+      status: 'trialing',
+      tier: 'unlimited_pro',
+      currentPeriodEnd: '2026-06-08T00:00:00.000Z'
+    };
+    client.rest._nextPayload = apiResponse({ subscription: snapshot });
 
     const result = await api.refreshSubscription();
 
-    assert.equal(
-      client.rest._lastCall.path,
-      '/v1/subscriptions/status',
-      'refreshSubscription() must delegate to /v1/subscriptions/status'
-    );
+    assert.equal(client.rest._lastCall.endpoint, '/v1/subscriptions/status');
     assert.deepEqual(result, snapshot);
     assert.deepEqual(api.currentAccount.subscription, snapshot);
+    assert.equal(api.currentAccount.isUnlimited, true);
   }
 
-  // ── 7. CurrentAccount.isUnlimited — status/tier matrix ───────────────────
-
   {
-    // No snapshot yet
     const ca = new CurrentAccount();
-    assert.equal(ca.subscription, undefined,  'subscription should start undefined');
-    assert.equal(ca.isUnlimited,  false,       'isUnlimited should be false when no snapshot');
+    assert.equal(ca.subscription, undefined, 'subscription should start undefined');
+    assert.equal(ca.isUnlimited, false, 'isUnlimited should be false when no snapshot exists');
 
-    // active=false
-    ca._update({ subscription: { active: false } });
+    ca._update({ subscription: { active: false, status: 'none' } });
     assert.equal(ca.isUnlimited, false, 'isUnlimited must be false when active=false');
 
-    // active=true but status=past_due
-    ca._update({ subscription: { active: true, status: 'past_due', tier: 'unlimited' } });
-    assert.equal(ca.isUnlimited, false, 'isUnlimited must be false for past_due');
-
-    // active=true, status=active, tier not unlimited
     ca._update({ subscription: { active: true, status: 'active', tier: 'free' } });
-    assert.equal(ca.isUnlimited, false, 'isUnlimited must be false for non-unlimited tier');
+    assert.equal(ca.isUnlimited, false, 'isUnlimited must be false for non-unlimited tiers');
 
-    // active=true, status=active, tier=unlimited
     ca._update({ subscription: { active: true, status: 'active', tier: 'unlimited' } });
     assert.equal(ca.isUnlimited, true, 'isUnlimited must be true for active unlimited');
 
-    // active=true, status=trialing, tier=unlimited
-    ca._update({ subscription: { active: true, status: 'trialing', tier: 'unlimited' } });
-    assert.equal(ca.isUnlimited, true, 'isUnlimited must be true for trialing unlimited');
+    ca._update({ subscription: { active: true, status: 'trialing', tier: 'unlimited_pro' } });
+    assert.equal(ca.isUnlimited, true, 'isUnlimited must be true for trialing unlimited_pro');
 
-    // _clear() resets subscription
+    ca._update({ subscription: { active: true, status: 'grace_period', tier: 'unlimited' } });
+    assert.equal(ca.isUnlimited, true, 'isUnlimited must be true during grace period');
+
+    ca._update({
+      subscription: { active: true, status: 'cancel_at_period_end', tier: 'unlimited_pro' }
+    });
+    assert.equal(ca.isUnlimited, true, 'isUnlimited must stay true until period end');
+
     ca._clear();
     assert.equal(ca.subscription, undefined, '_clear() must reset subscription to undefined');
-    assert.equal(ca.isUnlimited,  false,     '_clear() must reset isUnlimited to false');
+    assert.equal(ca.isUnlimited, false, '_clear() must reset isUnlimited to false');
   }
-
-  // ── 8. CurrentAccount subscription emits 'updated' ───────────────────────
 
   {
     const ca = new CurrentAccount();
@@ -296,45 +252,67 @@ async function run() {
     const off = ca.on('updated', (keys) => updatedKeys.push(...keys));
 
     ca._update({ subscription: { active: true, status: 'active', tier: 'unlimited' } });
-    assert.ok(updatedKeys.includes('subscription'), "updated event must include 'subscription' key");
+    assert.ok(updatedKeys.includes('subscription'), "updated event must include 'subscription'");
 
     off();
   }
 
-  // ── 9. Existing balance API is unchanged ─────────────────────────────────
-
   {
-    // balance field still present on defaults
-    const ca = new CurrentAccount();
-    assert.ok(ca.balance, 'balance must still be present');
-    assert.ok(ca.balance.sogni, 'balance.sogni must still be present');
-    assert.ok(ca.balance.spark, 'balance.spark must still be present');
-
-    // refreshBalance still works
     const { api, client } = makeApi();
     const balances = {
-      sogni: { settled: '10', credit: '0', debit: '0', net: '10', relaxedUnclaimed: '0', fastUnclaimed: '0' },
-      spark: { settled: '5',  credit: '0', debit: '0', net: '5',  premiumCredit: '0', relaxedUnclaimed: '0', fastUnclaimed: '0' }
+      sogni: {
+        settled: '10',
+        credit: '0',
+        debit: '0',
+        net: '10',
+        relaxedUnclaimed: '0',
+        fastUnclaimed: '0'
+      },
+      spark: {
+        settled: '5',
+        credit: '0',
+        debit: '0',
+        net: '5',
+        premiumCredit: '0',
+        relaxedUnclaimed: '0',
+        fastUnclaimed: '0'
+      }
     };
     client.rest._nextPayload = apiResponse(balances);
     await api.refreshBalance();
-    assert.deepEqual(api.currentAccount.balance, balances, 'refreshBalance() must still update balance');
+    assert.deepEqual(api.currentAccount.balance, balances, 'refreshBalance() must still work');
   }
 
-  // ── 10. Public type exports reachable from package root ──────────────────
-
   {
-    // These would throw a require() error if not exported.
     const pkgRoot = require('../dist/index.js');
+    assert.equal(typeof pkgRoot.CurrentAccount, 'function', 'CurrentAccount must be exported');
+    assert.equal(typeof pkgRoot.ApiError, 'function', 'ApiError must be exported');
 
-    // Value exports (classes + functions)
-    assert.ok(typeof pkgRoot.CurrentAccount === 'function', 'CurrentAccount must be exported');
-    assert.ok(typeof pkgRoot.ApiError === 'function',        'ApiError must be exported');
-
-    // Type-level exports: in CJS compiled output types are elided, but
-    // symbols that share name with runtime values are present.
-    // For pure-type exports we just verify the module loads cleanly (no throw above).
-    // The TS compiler catching wrong shapes is the real guard.
+    const declarations = fs.readFileSync(path.join(__dirname, '../dist/index.d.ts'), 'utf8');
+    for (const exportedType of [
+      'SubscriptionEntitlementSnapshot',
+      'SubscriptionPlan',
+      'SubscriptionPlanId',
+      'SubscriptionRedirectType',
+      'SubscriptionCheckoutResult',
+      'SubscriptionPortalSession',
+      'CreateSubscriptionCheckoutOptions'
+    ]) {
+      assert.ok(
+        declarations.includes(exportedType),
+        `${exportedType} must be exported from root declarations`
+      );
+    }
+    assert.equal(
+      declarations.includes('getSubscriptionUsage'),
+      false,
+      'getSubscriptionUsage must not be part of the public SDK surface'
+    );
+    assert.equal(
+      declarations.includes('SubscriptionUsage'),
+      false,
+      'SubscriptionUsage must not be exported from root declarations'
+    );
   }
 
   console.log('check-subscription-api: ALL TESTS PASSED');

--- a/scripts/check-subscription-api.cjs
+++ b/scripts/check-subscription-api.cjs
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for the subscription API surface added in this branch.
+ *
+ * Verifies:
+ *   - AccountApi methods call the correct endpoints with the right HTTP
+ *     method and body.
+ *   - Responses are unwrapped from the `{ status, data }` envelope.
+ *   - getSubscriptionStatus() propagates the snapshot to currentAccount.
+ *   - CurrentAccount.subscription accessor and isUnlimited getter behave
+ *     correctly across the full status/tier matrix.
+ *   - _clear() resets subscription to undefined.
+ *   - refreshSubscription() is a convenience alias that also updates
+ *     currentAccount.
+ *
+ * Runs against the compiled dist/ output so it doubles as a build-smoke
+ * test for the subscription types being present at the public export.
+ */
+
+'use strict';
+
+const assert = require('node:assert/strict');
+
+// ─── Load compiled artefacts ─────────────────────────────────────────────────
+
+const AccountApi   = require('../dist/Account/index.js').default;
+const CurrentAccount = require('../dist/Account/CurrentAccount.js').default;
+
+// ─── Stub infrastructure ─────────────────────────────────────────────────────
+
+class StubAuth {
+  constructor() { this.isAuthenticated = true; }
+  async authenticateRequest(init) { return init ?? {}; }
+  clear() { this.isAuthenticated = false; }
+  on()  {}
+  off() {}
+}
+
+class StubSocket {
+  get isConnected() { return false; }
+  get supernetType() { return 'fast'; }
+  on()  {}
+  off() {}
+}
+
+function makeStubClient() {
+  const auth   = new StubAuth();
+  const socket = new StubSocket();
+
+  // Minimal RestClient stub: captures last call, resolves with `_nextPayload`.
+  const rest = {
+    baseUrl: 'https://api.example.test',
+    _lastCall: null,
+    _nextPayload: null,
+    async get(path, _query) {
+      this._lastCall = { method: 'GET', path, body: null };
+      return this._nextPayload;
+    },
+    async post(path, body) {
+      this._lastCall = { method: 'POST', path, body };
+      return this._nextPayload;
+    }
+  };
+
+  const client = {
+    auth,
+    socket,
+    rest,
+    on()  {},
+    off() {}
+  };
+
+  return client;
+}
+
+const STUB_EIP712 = {};
+
+function makeApi() {
+  const client = makeStubClient();
+  const config = { client, eip712: STUB_EIP712 };
+  const api = new AccountApi(config);
+  return { api, client };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function apiResponse(data) {
+  return { status: 'success', data };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+async function run() {
+
+  // ── 1. getSubscriptionStatus ──────────────────────────────────────────────
+
+  {
+    const { api, client } = makeApi();
+    const snapshot = {
+      active: true,
+      status: 'active',
+      tier: 'unlimited',
+      planId: 'unlimited_monthly',
+      provider: 'stripe',
+      currentPeriodStart: 1700000000,
+      currentPeriodEnd:   1702678400,
+      cancelAtPeriodEnd: false
+    };
+    client.rest._nextPayload = apiResponse(snapshot);
+
+    const result = await api.getSubscriptionStatus();
+
+    assert.equal(
+      client.rest._lastCall.path,
+      '/v1/subscriptions/status',
+      'getSubscriptionStatus() must GET /v1/subscriptions/status'
+    );
+    assert.equal(client.rest._lastCall.method, 'GET');
+    assert.deepEqual(result, snapshot, 'getSubscriptionStatus() must return unwrapped snapshot');
+
+    // Snapshot propagates to currentAccount
+    assert.deepEqual(
+      api.currentAccount.subscription,
+      snapshot,
+      'getSubscriptionStatus() must update currentAccount.subscription'
+    );
+
+    // isUnlimited gate
+    assert.equal(
+      api.currentAccount.isUnlimited,
+      true,
+      'isUnlimited must be true for active unlimited subscription'
+    );
+  }
+
+  // ── 2. getSubscriptionPlans ───────────────────────────────────────────────
+
+  {
+    const { api, client } = makeApi();
+    const plans = [
+      {
+        planId: 'unlimited_monthly',
+        name: 'Unlimited Monthly',
+        term: 'monthly',
+        currency: 'usd',
+        price: 999,
+        displayPrice: '$9.99/mo',
+        tier: 'unlimited',
+        trialAvailable: true,
+        trialDays: 7,
+        features: ['Unlimited images', 'Unlimited videos']
+      }
+    ];
+    client.rest._nextPayload = apiResponse(plans);
+
+    const result = await api.getSubscriptionPlans();
+
+    assert.equal(
+      client.rest._lastCall.path,
+      '/v1/subscriptions/plans',
+      'getSubscriptionPlans() must GET /v1/subscriptions/plans'
+    );
+    assert.equal(client.rest._lastCall.method, 'GET');
+    assert.deepEqual(result, plans, 'getSubscriptionPlans() must return unwrapped plan array');
+    assert.equal(result.length, 1);
+    assert.equal(result[0].planId, 'unlimited_monthly');
+  }
+
+  // ── 3. getSubscriptionUsage ───────────────────────────────────────────────
+
+  {
+    const { api, client } = makeApi();
+    const usage = {
+      imagesGenerated: 42,
+      videosGenerated: 7,
+      tokensUsed: 18500,
+      periodStart: 1700000000,
+      periodEnd:   1702678400
+    };
+    client.rest._nextPayload = apiResponse(usage);
+
+    const result = await api.getSubscriptionUsage();
+
+    assert.equal(
+      client.rest._lastCall.path,
+      '/v1/subscriptions/usage',
+      'getSubscriptionUsage() must GET /v1/subscriptions/usage'
+    );
+    assert.equal(client.rest._lastCall.method, 'GET');
+    assert.deepEqual(result, usage, 'getSubscriptionUsage() must return unwrapped usage object');
+  }
+
+  // ── 4. createSubscriptionCheckout ────────────────────────────────────────
+
+  {
+    const { api, client } = makeApi();
+    client.rest._nextPayload = apiResponse({ url: 'https://checkout.stripe.com/pay/cs_test_abc123' });
+
+    const result = await api.createSubscriptionCheckout('unlimited_monthly', 'monthly');
+
+    assert.equal(
+      client.rest._lastCall.path,
+      '/v1/iap/stripe/subscribe',
+      'createSubscriptionCheckout() must POST /v1/iap/stripe/subscribe'
+    );
+    assert.equal(client.rest._lastCall.method, 'POST');
+    assert.deepEqual(
+      client.rest._lastCall.body,
+      { planId: 'unlimited_monthly', term: 'monthly' },
+      'createSubscriptionCheckout() must send planId + term in body'
+    );
+    assert.equal(result.url, 'https://checkout.stripe.com/pay/cs_test_abc123');
+
+    // annual term
+    client.rest._nextPayload = apiResponse({ url: 'https://checkout.stripe.com/pay/cs_test_annual' });
+    await api.createSubscriptionCheckout('unlimited_annual', 'annual');
+    assert.deepEqual(
+      client.rest._lastCall.body,
+      { planId: 'unlimited_annual', term: 'annual' }
+    );
+  }
+
+  // ── 5. createSubscriptionPortalSession ───────────────────────────────────
+
+  {
+    const { api, client } = makeApi();
+    client.rest._nextPayload = apiResponse({ url: 'https://billing.stripe.com/session/bps_test_xyz' });
+
+    const result = await api.createSubscriptionPortalSession();
+
+    assert.equal(
+      client.rest._lastCall.path,
+      '/v1/subscriptions/stripe/portal',
+      'createSubscriptionPortalSession() must POST /v1/subscriptions/stripe/portal'
+    );
+    assert.equal(client.rest._lastCall.method, 'POST');
+    assert.equal(result.url, 'https://billing.stripe.com/session/bps_test_xyz');
+  }
+
+  // ── 6. refreshSubscription (alias) ───────────────────────────────────────
+
+  {
+    const { api, client } = makeApi();
+    const snapshot = { active: true, status: 'trialing', tier: 'unlimited', planId: 'unlimited_monthly' };
+    client.rest._nextPayload = apiResponse(snapshot);
+
+    const result = await api.refreshSubscription();
+
+    assert.equal(
+      client.rest._lastCall.path,
+      '/v1/subscriptions/status',
+      'refreshSubscription() must delegate to /v1/subscriptions/status'
+    );
+    assert.deepEqual(result, snapshot);
+    assert.deepEqual(api.currentAccount.subscription, snapshot);
+  }
+
+  // ── 7. CurrentAccount.isUnlimited — status/tier matrix ───────────────────
+
+  {
+    // No snapshot yet
+    const ca = new CurrentAccount();
+    assert.equal(ca.subscription, undefined,  'subscription should start undefined');
+    assert.equal(ca.isUnlimited,  false,       'isUnlimited should be false when no snapshot');
+
+    // active=false
+    ca._update({ subscription: { active: false } });
+    assert.equal(ca.isUnlimited, false, 'isUnlimited must be false when active=false');
+
+    // active=true but status=past_due
+    ca._update({ subscription: { active: true, status: 'past_due', tier: 'unlimited' } });
+    assert.equal(ca.isUnlimited, false, 'isUnlimited must be false for past_due');
+
+    // active=true, status=active, tier not unlimited
+    ca._update({ subscription: { active: true, status: 'active', tier: 'free' } });
+    assert.equal(ca.isUnlimited, false, 'isUnlimited must be false for non-unlimited tier');
+
+    // active=true, status=active, tier=unlimited
+    ca._update({ subscription: { active: true, status: 'active', tier: 'unlimited' } });
+    assert.equal(ca.isUnlimited, true, 'isUnlimited must be true for active unlimited');
+
+    // active=true, status=trialing, tier=unlimited
+    ca._update({ subscription: { active: true, status: 'trialing', tier: 'unlimited' } });
+    assert.equal(ca.isUnlimited, true, 'isUnlimited must be true for trialing unlimited');
+
+    // _clear() resets subscription
+    ca._clear();
+    assert.equal(ca.subscription, undefined, '_clear() must reset subscription to undefined');
+    assert.equal(ca.isUnlimited,  false,     '_clear() must reset isUnlimited to false');
+  }
+
+  // ── 8. CurrentAccount subscription emits 'updated' ───────────────────────
+
+  {
+    const ca = new CurrentAccount();
+    const updatedKeys = [];
+    const off = ca.on('updated', (keys) => updatedKeys.push(...keys));
+
+    ca._update({ subscription: { active: true, status: 'active', tier: 'unlimited' } });
+    assert.ok(updatedKeys.includes('subscription'), "updated event must include 'subscription' key");
+
+    off();
+  }
+
+  // ── 9. Existing balance API is unchanged ─────────────────────────────────
+
+  {
+    // balance field still present on defaults
+    const ca = new CurrentAccount();
+    assert.ok(ca.balance, 'balance must still be present');
+    assert.ok(ca.balance.sogni, 'balance.sogni must still be present');
+    assert.ok(ca.balance.spark, 'balance.spark must still be present');
+
+    // refreshBalance still works
+    const { api, client } = makeApi();
+    const balances = {
+      sogni: { settled: '10', credit: '0', debit: '0', net: '10', relaxedUnclaimed: '0', fastUnclaimed: '0' },
+      spark: { settled: '5',  credit: '0', debit: '0', net: '5',  premiumCredit: '0', relaxedUnclaimed: '0', fastUnclaimed: '0' }
+    };
+    client.rest._nextPayload = apiResponse(balances);
+    await api.refreshBalance();
+    assert.deepEqual(api.currentAccount.balance, balances, 'refreshBalance() must still update balance');
+  }
+
+  // ── 10. Public type exports reachable from package root ──────────────────
+
+  {
+    // These would throw a require() error if not exported.
+    const pkgRoot = require('../dist/index.js');
+
+    // Value exports (classes + functions)
+    assert.ok(typeof pkgRoot.CurrentAccount === 'function', 'CurrentAccount must be exported');
+    assert.ok(typeof pkgRoot.ApiError === 'function',        'ApiError must be exported');
+
+    // Type-level exports: in CJS compiled output types are elided, but
+    // symbols that share name with runtime values are present.
+    // For pure-type exports we just verify the module loads cleanly (no throw above).
+    // The TS compiler catching wrong shapes is the real guard.
+  }
+
+  console.log('check-subscription-api: ALL TESTS PASSED');
+}
+
+run().catch((err) => {
+  console.error('check-subscription-api: FAIL');
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/Account/CurrentAccount.ts
+++ b/src/Account/CurrentAccount.ts
@@ -1,5 +1,6 @@
 import DataEntity from '../lib/DataEntity.js';
 import { Balances } from './types.js';
+import { SubscriptionEntitlementSnapshot } from './subscription.types.js';
 import { SupernetType } from '../ApiClient/WebSocketClient/types.js';
 /**
  * @inline
@@ -20,6 +21,16 @@ export interface AccountData {
   walletAddress?: string;
   username?: string;
   email?: string;
+  /**
+   * The most recently fetched subscription entitlement snapshot.
+   * `undefined` until {@link AccountApi.getSubscriptionStatus} or
+   * {@link AccountApi.refreshSubscription} has been called.
+   *
+   * Subscribe to the `'updated'` event (inherited from `DataEntity`) to react
+   * to changes — the `changedKeys` array will include `'subscription'` when
+   * this field is refreshed.
+   */
+  subscription?: SubscriptionEntitlementSnapshot;
 }
 
 function getDefaults(): AccountData {
@@ -42,7 +53,8 @@ function getDefaults(): AccountData {
       }
     },
     walletAddress: undefined,
-    username: undefined
+    username: undefined,
+    subscription: undefined
   };
 }
 
@@ -85,6 +97,30 @@ class CurrentAccount extends DataEntity<AccountData> {
 
   get email() {
     return this.data.email;
+  }
+
+  /**
+   * The most recently cached subscription entitlement snapshot.
+   * `undefined` until {@link AccountApi.getSubscriptionStatus} or
+   * {@link AccountApi.refreshSubscription} has been called.
+   */
+  get subscription(): SubscriptionEntitlementSnapshot | undefined {
+    return this.data.subscription;
+  }
+
+  /**
+   * Convenience getter — `true` when the account has an active or trialing
+   * subscription with the `"unlimited"` tier.
+   *
+   * Returns `false` when no entitlement snapshot has been fetched yet or when
+   * the subscription is not active/trialing. Call
+   * {@link AccountApi.refreshSubscription} to populate the snapshot first.
+   */
+  get isUnlimited(): boolean {
+    const sub = this.data.subscription;
+    if (!sub || !sub.active) return false;
+    const liveStatus = sub.status === 'active' || sub.status === 'trialing';
+    return liveStatus && sub.tier === 'unlimited';
   }
 }
 

--- a/src/Account/CurrentAccount.ts
+++ b/src/Account/CurrentAccount.ts
@@ -27,7 +27,7 @@ export interface AccountData {
    * {@link AccountApi.refreshSubscription} has been called.
    *
    * Subscribe to the `'updated'` event (inherited from `DataEntity`) to react
-   * to changes — the `changedKeys` array will include `'subscription'` when
+   * to changes; the `changedKeys` array will include `'subscription'` when
    * this field is refreshed.
    */
   subscription?: SubscriptionEntitlementSnapshot;
@@ -109,18 +109,19 @@ class CurrentAccount extends DataEntity<AccountData> {
   }
 
   /**
-   * Convenience getter — `true` when the account has an active or trialing
-   * subscription on any Unlimited tier (`"unlimited"` or `"unlimited_pro"`).
+   * Convenience getter - `true` when the account has an effective
+   * subscription entitlement on any Unlimited tier (`"unlimited"` or
+   * `"unlimited_pro"`).
    *
-   * Returns `false` when no entitlement snapshot has been fetched yet or when
-   * the subscription is not active/trialing. Call
-   * {@link AccountApi.refreshSubscription} to populate the snapshot first.
+   * Returns `false` when no entitlement snapshot has been fetched yet, when
+   * the server reports no active entitlement, or when the tier is not an
+   * Unlimited tier. Call {@link AccountApi.refreshSubscription} to populate the
+   * snapshot first.
    */
   get isUnlimited(): boolean {
     const sub = this.data.subscription;
     if (!sub || !sub.active) return false;
-    const liveStatus = sub.status === 'active' || sub.status === 'trialing';
-    return liveStatus && (sub.tier === 'unlimited' || sub.tier === 'unlimited_pro');
+    return sub.tier === 'unlimited' || sub.tier === 'unlimited_pro';
   }
 }
 

--- a/src/Account/CurrentAccount.ts
+++ b/src/Account/CurrentAccount.ts
@@ -110,7 +110,7 @@ class CurrentAccount extends DataEntity<AccountData> {
 
   /**
    * Convenience getter — `true` when the account has an active or trialing
-   * subscription with the `"unlimited"` tier.
+   * subscription on any Unlimited tier (`"unlimited"` or `"unlimited_pro"`).
    *
    * Returns `false` when no entitlement snapshot has been fetched yet or when
    * the subscription is not active/trialing. Call
@@ -120,7 +120,7 @@ class CurrentAccount extends DataEntity<AccountData> {
     const sub = this.data.subscription;
     if (!sub || !sub.active) return false;
     const liveStatus = sub.status === 'active' || sub.status === 'trialing';
-    return liveStatus && sub.tier === 'unlimited';
+    return liveStatus && (sub.tier === 'unlimited' || sub.tier === 'unlimited_pro');
   }
 }
 

--- a/src/Account/index.ts
+++ b/src/Account/index.ts
@@ -15,9 +15,15 @@ import {
   TxHistoryParams
 } from './types.js';
 import {
+  CreateSubscriptionCheckoutOptions,
+  SubscriptionCheckoutResult,
   SubscriptionEntitlementSnapshot,
+  SubscriptionPlanId,
+  SubscriptionPlansResponseData,
   SubscriptionPlan,
-  SubscriptionUsage
+  SubscriptionPortalSession,
+  SubscriptionStatusResponseData,
+  SubscriptionTerm
 } from './subscription.types.js';
 import ApiGroup, { ApiConfig } from '../ApiGroup.js';
 import { parseEther, pbkdf2, toUtf8Bytes, Wallet } from 'ethers';
@@ -619,14 +625,15 @@ class AccountApi extends ApiGroup {
     });
   }
 
-  // ─── Subscription ────────────────────────────────────────────────────────
+  // Subscription
 
   /**
    * Fetch the current user's subscription entitlement snapshot.
    *
-   * Returns an object describing whether the account has an active
-   * subscription, the plan/tier, period boundaries, usage, limits, and
-   * enabled capabilities. When no subscription exists, `active` is `false`.
+   * Returns an object describing whether the account has an effective
+   * subscription entitlement, the tier, period boundaries, usage, limits, and
+   * enabled capabilities. When no subscription exists, `active` is `false` and
+   * `status` is `'none'`.
    *
    * Also updates `currentAccount.subscription` so callers can read the
    * snapshot from the observable entity without re-fetching.
@@ -640,45 +647,30 @@ class AccountApi extends ApiGroup {
    * ```
    */
   async getSubscriptionStatus(): Promise<SubscriptionEntitlementSnapshot> {
-    const res = await this.client.rest.get<ApiResponse<SubscriptionEntitlementSnapshot>>(
+    const res = await this.client.rest.get<ApiResponse<SubscriptionStatusResponseData>>(
       '/v1/subscriptions/status'
     );
-    this.currentAccount._update({ subscription: res.data });
-    return res.data;
+    this.currentAccount._update({ subscription: res.data.subscription });
+    return res.data.subscription;
   }
 
   /**
    * Fetch the list of available subscription plans.
    *
-   * This is a public endpoint — no authentication is required.
+   * This is a public endpoint; no authentication is required.
    *
    * @example
    * ```typescript
    * const plans = await sogni.account.getSubscriptionPlans();
-   * plans.forEach(p => console.log(p.name, p.displayPrice));
+   * plans.forEach(p => console.log(p.displayName, p.priceUsd));
    * ```
    */
   async getSubscriptionPlans(): Promise<SubscriptionPlan[]> {
-    const res = await this.client.rest.get<ApiResponse<SubscriptionPlan[]>>(
-      '/v1/subscriptions/plans'
-    );
-    return res.data;
-  }
-
-  /**
-   * Fetch per-period usage counters for the authenticated user's active subscription.
-   *
-   * @example
-   * ```typescript
-   * const usage = await sogni.account.getSubscriptionUsage();
-   * console.log('Images generated this period:', usage.imagesGenerated);
-   * ```
-   */
-  async getSubscriptionUsage(): Promise<SubscriptionUsage> {
-    const res = await this.client.rest.get<ApiResponse<SubscriptionUsage>>(
-      '/v1/subscriptions/usage'
-    );
-    return res.data;
+    const res =
+      await this.client.rest.get<ApiResponse<SubscriptionPlansResponseData>>(
+        '/v1/subscriptions/plans'
+      );
+    return res.data.plans;
   }
 
   /**
@@ -690,20 +682,27 @@ class AccountApi extends ApiGroup {
    *
    * @param planId - The plan identifier from {@link getSubscriptionPlans}
    * @param term   - Billing cadence: `'monthly'` or `'annual'`
+   * @param options - Optional checkout metadata and redirect target.
    *
    * @example
    * ```typescript
-   * const { url } = await sogni.account.createSubscriptionCheckout('unlimited_monthly', 'monthly');
+   * const { url } = await sogni.account.createSubscriptionCheckout('unlimited', 'monthly');
    * window.location.href = url;
    * ```
    */
   async createSubscriptionCheckout(
-    planId: string,
-    term: 'monthly' | 'annual'
-  ): Promise<{ url: string }> {
-    const res = await this.client.rest.post<ApiResponse<{ url: string }>>(
+    planId: SubscriptionPlanId,
+    term: SubscriptionTerm,
+    options: CreateSubscriptionCheckoutOptions = {}
+  ): Promise<SubscriptionCheckoutResult> {
+    const res = await this.client.rest.post<ApiResponse<SubscriptionCheckoutResult>>(
       '/v1/iap/stripe/subscribe',
-      { planId, term }
+      {
+        planId,
+        term,
+        redirectType: options.redirectType ?? 'web',
+        ...(options.appSource ? { appSource: options.appSource } : {})
+      }
     );
     return res.data;
   }
@@ -720,8 +719,8 @@ class AccountApi extends ApiGroup {
    * window.location.href = url;
    * ```
    */
-  async createSubscriptionPortalSession(): Promise<{ url: string }> {
-    const res = await this.client.rest.post<ApiResponse<{ url: string }>>(
+  async createSubscriptionPortalSession(): Promise<SubscriptionPortalSession> {
+    const res = await this.client.rest.post<ApiResponse<SubscriptionPortalSession>>(
       '/v1/subscriptions/stripe/portal',
       {}
     );
@@ -732,8 +731,8 @@ class AccountApi extends ApiGroup {
    * Refresh the cached subscription entitlement on `currentAccount`.
    *
    * Convenience wrapper around {@link getSubscriptionStatus} that makes the
-   * intent — "I want to pull fresh entitlement data into the observable
-   * account entity" — explicit at the call site.
+   * intent ("I want to pull fresh entitlement data into the observable
+   * account entity") explicit at the call site.
    *
    * @example
    * ```typescript

--- a/src/Account/index.ts
+++ b/src/Account/index.ts
@@ -14,6 +14,11 @@ import {
   TxHistoryEntry,
   TxHistoryParams
 } from './types.js';
+import {
+  SubscriptionEntitlementSnapshot,
+  SubscriptionPlan,
+  SubscriptionUsage
+} from './subscription.types.js';
 import ApiGroup, { ApiConfig } from '../ApiGroup.js';
 import { parseEther, pbkdf2, toUtf8Bytes, Wallet } from 'ethers';
 import { ApiError, ApiResponse } from '../ApiClient/index.js';
@@ -612,6 +617,132 @@ class AccountApi extends ApiGroup {
       deadline: message.deadline,
       approveSignature: signature
     });
+  }
+
+  // ─── Subscription ────────────────────────────────────────────────────────
+
+  /**
+   * Fetch the current user's subscription entitlement snapshot.
+   *
+   * Returns an object describing whether the account has an active
+   * subscription, the plan/tier, period boundaries, usage, limits, and
+   * enabled capabilities. When no subscription exists, `active` is `false`.
+   *
+   * Also updates `currentAccount.subscription` so callers can read the
+   * snapshot from the observable entity without re-fetching.
+   *
+   * @example
+   * ```typescript
+   * const snap = await sogni.account.getSubscriptionStatus();
+   * if (snap.active) {
+   *   console.log('Plan:', snap.tier, 'until', snap.currentPeriodEnd);
+   * }
+   * ```
+   */
+  async getSubscriptionStatus(): Promise<SubscriptionEntitlementSnapshot> {
+    const res = await this.client.rest.get<ApiResponse<SubscriptionEntitlementSnapshot>>(
+      '/v1/subscriptions/status'
+    );
+    this.currentAccount._update({ subscription: res.data });
+    return res.data;
+  }
+
+  /**
+   * Fetch the list of available subscription plans.
+   *
+   * This is a public endpoint — no authentication is required.
+   *
+   * @example
+   * ```typescript
+   * const plans = await sogni.account.getSubscriptionPlans();
+   * plans.forEach(p => console.log(p.name, p.displayPrice));
+   * ```
+   */
+  async getSubscriptionPlans(): Promise<SubscriptionPlan[]> {
+    const res = await this.client.rest.get<ApiResponse<SubscriptionPlan[]>>(
+      '/v1/subscriptions/plans'
+    );
+    return res.data;
+  }
+
+  /**
+   * Fetch per-period usage counters for the authenticated user's active subscription.
+   *
+   * @example
+   * ```typescript
+   * const usage = await sogni.account.getSubscriptionUsage();
+   * console.log('Images generated this period:', usage.imagesGenerated);
+   * ```
+   */
+  async getSubscriptionUsage(): Promise<SubscriptionUsage> {
+    const res = await this.client.rest.get<ApiResponse<SubscriptionUsage>>(
+      '/v1/subscriptions/usage'
+    );
+    return res.data;
+  }
+
+  /**
+   * Create a Stripe checkout session to subscribe to a plan.
+   *
+   * Returns a `url` to which the user should be redirected to complete payment.
+   * After a successful checkout Stripe will redirect back to your configured
+   * return URL and the subscription entitlement will become active.
+   *
+   * @param planId - The plan identifier from {@link getSubscriptionPlans}
+   * @param term   - Billing cadence: `'monthly'` or `'annual'`
+   *
+   * @example
+   * ```typescript
+   * const { url } = await sogni.account.createSubscriptionCheckout('unlimited_monthly', 'monthly');
+   * window.location.href = url;
+   * ```
+   */
+  async createSubscriptionCheckout(
+    planId: string,
+    term: 'monthly' | 'annual'
+  ): Promise<{ url: string }> {
+    const res = await this.client.rest.post<ApiResponse<{ url: string }>>(
+      '/v1/iap/stripe/subscribe',
+      { planId, term }
+    );
+    return res.data;
+  }
+
+  /**
+   * Create a Stripe customer portal session for managing an existing subscription.
+   *
+   * Returns a `url` to which the user should be redirected. The portal lets
+   * them update payment methods, cancel, or view invoices.
+   *
+   * @example
+   * ```typescript
+   * const { url } = await sogni.account.createSubscriptionPortalSession();
+   * window.location.href = url;
+   * ```
+   */
+  async createSubscriptionPortalSession(): Promise<{ url: string }> {
+    const res = await this.client.rest.post<ApiResponse<{ url: string }>>(
+      '/v1/subscriptions/stripe/portal',
+      {}
+    );
+    return res.data;
+  }
+
+  /**
+   * Refresh the cached subscription entitlement on `currentAccount`.
+   *
+   * Convenience wrapper around {@link getSubscriptionStatus} that makes the
+   * intent — "I want to pull fresh entitlement data into the observable
+   * account entity" — explicit at the call site.
+   *
+   * @example
+   * ```typescript
+   * await sogni.account.refreshSubscription();
+   * console.log(sogni.account.currentAccount.isUnlimited);
+   * ```
+   */
+  async refreshSubscription(): Promise<SubscriptionEntitlementSnapshot> {
+    return this.getSubscriptionStatus();
   }
 }
 

--- a/src/Account/subscription.types.ts
+++ b/src/Account/subscription.types.ts
@@ -1,0 +1,129 @@
+/**
+ * Subscription-related types for the Sogni SDK.
+ *
+ * These types mirror the server-side subscription surface exposed under
+ * `/v1/subscriptions/*` and `/v1/iap/stripe/*`. They are intentionally
+ * additive — the existing token-based balance and `tokenType` APIs are
+ * unchanged.
+ */
+
+/**
+ * How the current account session is billed:
+ * - `'auto'`         — no explicit mode; server picks based on context
+ * - `'tokens'`       — usage charged against the SOGNI/Spark token balance
+ * - `'subscription'` — usage covered by an active subscription entitlement
+ */
+export type BillingMode = 'auto' | 'tokens' | 'subscription';
+
+/**
+ * Lifecycle state of a subscription. Mirrors the server-side status enum.
+ */
+export type SubscriptionStatus =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'unpaid'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'paused';
+
+/**
+ * Billing term — monthly or annual.
+ */
+export type SubscriptionTerm = 'monthly' | 'annual';
+
+/**
+ * Current subscription entitlement snapshot returned by
+ * `GET /v1/subscriptions/status`.
+ *
+ * When the user has no active subscription, `active` will be `false` and
+ * most other fields will be absent.
+ */
+export interface SubscriptionEntitlementSnapshot {
+  /** Whether there is a currently active (or trialing) entitlement. */
+  active: boolean;
+  /** Lifecycle status of the subscription. Present when a subscription record exists. */
+  status?: SubscriptionStatus;
+  /** Internal plan identifier (e.g. `"unlimited_monthly"`). */
+  planId?: string;
+  /** Human-readable tier name (e.g. `"unlimited"`). */
+  tier?: string;
+  /** Payment provider (e.g. `"stripe"`, `"apple"`, `"google"`). */
+  provider?: string;
+  /** Unix timestamp (seconds) for the start of the current billing period. */
+  currentPeriodStart?: number;
+  /** Unix timestamp (seconds) for the end of the current billing period. */
+  currentPeriodEnd?: number;
+  /** When `true` the subscription will not auto-renew and will cancel at period end. */
+  cancelAtPeriodEnd?: boolean;
+  /** Per-period usage counters, if returned by the server. */
+  usage?: SubscriptionUsage;
+  /** Usage limits associated with the current plan, if returned by the server. */
+  limits?: SubscriptionLimits;
+  /**
+   * Feature flags or capability names enabled by this subscription.
+   * The exact set of strings is server-defined and may grow over time.
+   */
+  capabilities?: string[];
+}
+
+/**
+ * Per-period usage counters returned by `GET /v1/subscriptions/usage`.
+ *
+ * All counts reflect the current billing period unless noted otherwise.
+ */
+export interface SubscriptionUsage {
+  /** Number of image-generation jobs run in the current period. */
+  imagesGenerated?: number;
+  /** Number of video-generation jobs run in the current period. */
+  videosGenerated?: number;
+  /** Number of LLM chat tokens consumed in the current period. */
+  tokensUsed?: number;
+  /** Server-defined usage period start (Unix seconds). */
+  periodStart?: number;
+  /** Server-defined usage period end (Unix seconds). */
+  periodEnd?: number;
+}
+
+/**
+ * Plan-level limits associated with a subscription tier.
+ */
+export interface SubscriptionLimits {
+  /** Maximum images per billing period, or `null` for unlimited. */
+  imagesPerPeriod?: number | null;
+  /** Maximum videos per billing period, or `null` for unlimited. */
+  videosPerPeriod?: number | null;
+  /** Maximum LLM tokens per billing period, or `null` for unlimited. */
+  tokensPerPeriod?: number | null;
+}
+
+/**
+ * A single purchasable subscription plan returned by
+ * `GET /v1/subscriptions/plans`.
+ */
+export interface SubscriptionPlan {
+  /** Server-assigned plan identifier passed to checkout. */
+  planId: string;
+  /** Human-readable plan name (e.g. `"Unlimited Monthly"`). */
+  name: string;
+  /** Billing cadence for this plan variant. */
+  term: SubscriptionTerm;
+  /** ISO 4217 currency code for `price` (e.g. `"usd"`). */
+  currency: string;
+  /**
+   * Price in the smallest currency unit (e.g. cents for USD).
+   * Use `displayPrice` when showing to users.
+   */
+  price: number;
+  /** Human-readable formatted price string supplied by the server (e.g. `"$9.99/mo"`). */
+  displayPrice?: string;
+  /** Tier name this plan belongs to (e.g. `"unlimited"`). */
+  tier?: string;
+  /** Whether a free trial is available when subscribing via this plan. */
+  trialAvailable?: boolean;
+  /** Length of the free trial in days, if applicable. */
+  trialDays?: number;
+  /** Feature bullets or descriptions included with this plan. */
+  features?: string[];
+}

--- a/src/Account/subscription.types.ts
+++ b/src/Account/subscription.types.ts
@@ -1,129 +1,130 @@
 /**
  * Subscription-related types for the Sogni SDK.
  *
- * These types mirror the server-side subscription surface exposed under
- * `/v1/subscriptions/*` and `/v1/iap/stripe/*`. They are intentionally
- * additive — the existing token-based balance and `tokenType` APIs are
- * unchanged.
+ * These types mirror the public subscription API exposed by `sogni-api` under
+ * `/v1/subscriptions/*` and `/v1/iap/stripe/subscribe`.
  */
 
 /**
- * How the current account session is billed:
- * - `'auto'`         — no explicit mode; server picks based on context
- * - `'tokens'`       — usage charged against the SOGNI/Spark token balance
- * - `'subscription'` — usage covered by an active subscription entitlement
- */
-export type BillingMode = 'auto' | 'tokens' | 'subscription';
-
-/**
- * Lifecycle state of a subscription. Mirrors the server-side status enum.
+ * Lifecycle state returned by `GET /v1/subscriptions/status`.
  */
 export type SubscriptionStatus =
-  | 'active'
+  | 'none'
   | 'trialing'
+  | 'active'
+  | 'grace_period'
   | 'past_due'
+  | 'paused'
+  | 'cancel_at_period_end'
   | 'canceled'
-  | 'unpaid'
-  | 'incomplete'
-  | 'incomplete_expired'
-  | 'paused';
+  | 'expired'
+  | 'refunded';
 
 /**
- * Billing term — monthly or annual.
+ * Plan/tier identifiers accepted by the subscription checkout endpoint.
+ */
+export type SubscriptionPlanId = 'unlimited' | 'unlimited_pro';
+
+/**
+ * Billing term selector accepted by the subscription checkout endpoint.
  */
 export type SubscriptionTerm = 'monthly' | 'annual';
+
+/**
+ * Stripe recurring interval implied by the billing term.
+ */
+export type SubscriptionPlanInterval = 'month' | 'year';
+
+/**
+ * Checkout redirect target. The server uses this to choose the post-checkout
+ * return URL.
+ */
+export type SubscriptionRedirectType = 'web' | 'app' | 'dashboard' | 'photobooth';
 
 /**
  * Current subscription entitlement snapshot returned by
  * `GET /v1/subscriptions/status`.
  *
- * When the user has no active subscription, `active` will be `false` and
- * most other fields will be absent.
+ * When the user has no effective subscription, `active` is `false` and
+ * `status` is `'none'`.
  */
 export interface SubscriptionEntitlementSnapshot {
-  /** Whether there is a currently active (or trialing) entitlement. */
+  /** Whether the wallet currently has an effective entitlement. */
   active: boolean;
-  /** Lifecycle status of the subscription. Present when a subscription record exists. */
-  status?: SubscriptionStatus;
-  /** Internal plan identifier (e.g. `"unlimited_monthly"`). */
-  planId?: string;
-  /** Human-readable tier name (e.g. `"unlimited"`). */
-  tier?: string;
-  /** Payment provider (e.g. `"stripe"`, `"apple"`, `"google"`). */
-  provider?: string;
-  /** Unix timestamp (seconds) for the start of the current billing period. */
-  currentPeriodStart?: number;
-  /** Unix timestamp (seconds) for the end of the current billing period. */
-  currentPeriodEnd?: number;
-  /** When `true` the subscription will not auto-renew and will cancel at period end. */
+  /** Rich status string for display and entitlement state. */
+  status: SubscriptionStatus;
+  /** Plan/tier identifier, present when an entitlement exists. */
+  tier?: SubscriptionPlanId | string;
+  /** Payment provider, present when returned by the server. */
+  provider?: 'stripe' | 'apple' | 'google' | string;
+  /** ISO timestamp for the current period start, when returned by the server. */
+  currentPeriodStart?: string;
+  /** ISO timestamp for the current or effective entitlement period end. */
+  currentPeriodEnd?: string;
+  /** When `true`, the subscription remains entitled until `currentPeriodEnd`. */
   cancelAtPeriodEnd?: boolean;
-  /** Per-period usage counters, if returned by the server. */
-  usage?: SubscriptionUsage;
-  /** Usage limits associated with the current plan, if returned by the server. */
-  limits?: SubscriptionLimits;
-  /**
-   * Feature flags or capability names enabled by this subscription.
-   * The exact set of strings is server-defined and may grow over time.
-   */
-  capabilities?: string[];
+  /** Feature flags or capability names enabled by this subscription. */
+  capabilities?: Record<string, boolean>;
 }
 
 /**
- * Per-period usage counters returned by `GET /v1/subscriptions/usage`.
+ * Public subscription plan returned by `GET /v1/subscriptions/plans`.
  *
- * All counts reflect the current billing period unless noted otherwise.
- */
-export interface SubscriptionUsage {
-  /** Number of image-generation jobs run in the current period. */
-  imagesGenerated?: number;
-  /** Number of video-generation jobs run in the current period. */
-  videosGenerated?: number;
-  /** Number of LLM chat tokens consumed in the current period. */
-  tokensUsed?: number;
-  /** Server-defined usage period start (Unix seconds). */
-  periodStart?: number;
-  /** Server-defined usage period end (Unix seconds). */
-  periodEnd?: number;
-}
-
-/**
- * Plan-level limits associated with a subscription tier.
- */
-export interface SubscriptionLimits {
-  /** Maximum images per billing period, or `null` for unlimited. */
-  imagesPerPeriod?: number | null;
-  /** Maximum videos per billing period, or `null` for unlimited. */
-  videosPerPeriod?: number | null;
-  /** Maximum LLM tokens per billing period, or `null` for unlimited. */
-  tokensPerPeriod?: number | null;
-}
-
-/**
- * A single purchasable subscription plan returned by
- * `GET /v1/subscriptions/plans`.
+ * Stripe price identifiers are intentionally not exposed by the public API.
  */
 export interface SubscriptionPlan {
-  /** Server-assigned plan identifier passed to checkout. */
-  planId: string;
-  /** Human-readable plan name (e.g. `"Unlimited Monthly"`). */
-  name: string;
-  /** Billing cadence for this plan variant. */
+  /** Plan/tier identifier passed to checkout. */
+  planId: SubscriptionPlanId;
+  /** Alias of `planId`, included for display and filtering. */
+  tier: SubscriptionPlanId;
+  /** Billing cadence for this plan entry. */
   term: SubscriptionTerm;
-  /** ISO 4217 currency code for `price` (e.g. `"usd"`). */
-  currency: string;
+  /** Stripe recurring interval implied by `term`. */
+  interval: SubscriptionPlanInterval;
+  /** Display-only list price in whole USD. */
+  priceUsd: number;
+  /** Human-readable label supplied by the server. */
+  displayName: string;
+}
+
+/**
+ * Options for `AccountApi.createSubscriptionCheckout`.
+ */
+export interface CreateSubscriptionCheckoutOptions {
   /**
-   * Price in the smallest currency unit (e.g. cents for USD).
-   * Use `displayPrice` when showing to users.
+   * Post-checkout redirect target. Defaults to `'web'`.
    */
-  price: number;
-  /** Human-readable formatted price string supplied by the server (e.g. `"$9.99/mo"`). */
-  displayPrice?: string;
-  /** Tier name this plan belongs to (e.g. `"unlimited"`). */
-  tier?: string;
-  /** Whether a free trial is available when subscribing via this plan. */
-  trialAvailable?: boolean;
-  /** Length of the free trial in days, if applicable. */
-  trialDays?: number;
-  /** Feature bullets or descriptions included with this plan. */
-  features?: string[];
+  redirectType?: SubscriptionRedirectType;
+  /**
+   * Optional client app/source label stored in Stripe metadata.
+   */
+  appSource?: string;
+}
+
+/**
+ * Result returned by `AccountApi.createSubscriptionCheckout`.
+ */
+export interface SubscriptionCheckoutResult {
+  /** Optional server message describing the checkout session. */
+  message?: string;
+  /** Stripe Checkout URL to open in the user's browser. */
+  url: string;
+}
+
+/**
+ * Result returned by `AccountApi.createSubscriptionPortalSession`.
+ */
+export interface SubscriptionPortalSession {
+  /** Stripe Billing Portal URL to open in the user's browser. */
+  url: string;
+}
+
+/** @internal */
+export interface SubscriptionStatusResponseData {
+  subscription: SubscriptionEntitlementSnapshot;
+}
+
+/** @internal */
+export interface SubscriptionPlansResponseData {
+  plans: SubscriptionPlan[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,13 +43,16 @@ import type { ProjectEvent, JobEvent } from './Projects/types/events.js';
 import type { RawProject } from './Projects/types/RawProject.js';
 import type { Balances, Reward, TxHistoryEntry } from './Account/types.js';
 import type {
-  BillingMode,
+  CreateSubscriptionCheckoutOptions,
+  SubscriptionCheckoutResult,
   SubscriptionEntitlementSnapshot,
-  SubscriptionLimits,
+  SubscriptionPlanId,
+  SubscriptionPlanInterval,
   SubscriptionPlan,
+  SubscriptionPortalSession,
+  SubscriptionRedirectType,
   SubscriptionStatus,
-  SubscriptionTerm,
-  SubscriptionUsage
+  SubscriptionTerm
 } from './Account/subscription.types.js';
 import type { ToastMessage } from './ApiClient/WebSocketClient/events.js';
 import type DataEntity from './lib/DataEntity.js';
@@ -268,13 +271,16 @@ export type {
   Balances,
   Reward,
   TxHistoryEntry,
-  BillingMode,
+  CreateSubscriptionCheckoutOptions,
+  SubscriptionCheckoutResult,
   SubscriptionEntitlementSnapshot,
-  SubscriptionLimits,
+  SubscriptionPlanId,
+  SubscriptionPlanInterval,
   SubscriptionPlan,
+  SubscriptionPortalSession,
+  SubscriptionRedirectType,
   SubscriptionStatus,
   SubscriptionTerm,
-  SubscriptionUsage,
   SizePreset,
   EstimateRequest,
   CostEstimation,

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,15 @@ import {
 import type { ProjectEvent, JobEvent } from './Projects/types/events.js';
 import type { RawProject } from './Projects/types/RawProject.js';
 import type { Balances, Reward, TxHistoryEntry } from './Account/types.js';
+import type {
+  BillingMode,
+  SubscriptionEntitlementSnapshot,
+  SubscriptionLimits,
+  SubscriptionPlan,
+  SubscriptionStatus,
+  SubscriptionTerm,
+  SubscriptionUsage
+} from './Account/subscription.types.js';
 import type { ToastMessage } from './ApiClient/WebSocketClient/events.js';
 import type DataEntity from './lib/DataEntity.js';
 import {
@@ -259,6 +268,13 @@ export type {
   Balances,
   Reward,
   TxHistoryEntry,
+  BillingMode,
+  SubscriptionEntitlementSnapshot,
+  SubscriptionLimits,
+  SubscriptionPlan,
+  SubscriptionStatus,
+  SubscriptionTerm,
+  SubscriptionUsage,
   SizePreset,
   EstimateRequest,
   CostEstimation,


### PR DESCRIPTION
## Summary

This PR aligns the Unlimited subscription SDK surface with the current public `sogni-api` contract and keeps fair-use accounting out of the client-side public API.

## What Changed

- Added source-grounded subscription entitlement, plan catalog, checkout, and portal types/methods on `account`.
- Corrected REST envelope handling for subscription status and plans.
- Updated `currentAccount.subscription` and `currentAccount.isUnlimited` so `unlimited` and `unlimited_pro` are both recognized while the server reports an active entitlement.
- Removed public usage counters and plan-limit structures from the SDK surface; Unlimited fair-use accounting and enforcement remain dynamic in `sogni-socket`.
- Added `test:subscription-api` as a compiled smoke test for the public SDK surface.
- Updated `README.md`, `llms.txt`, and `llms-full.txt` with the entitlement-only client contract.

## Validation

- `sogni commit-check sogni-client -F /tmp/sogni-client-commit.rtZAc6`
- `npm run test:subscription-api`
- `npx prettier --check src/Account/subscription.types.ts src/Account/index.ts src/Account/CurrentAccount.ts src/index.ts scripts/check-subscription-api.cjs package.json`
- `git diff --check`

## Notes

Checkout and portal session creation require user authentication; API-key callers are rejected by the API for those browser redirect operations. The SDK intentionally does not expose per-period Unlimited usage counters or fixed fair-use limits for clients to store or display.
