### PR TITLE
feat(subscription): add paymentPending to entitlement snapshot

### DIFF
--- a/src/Account/index.ts
+++ b/src/Account/index.ts
@@ -218,6 +218,7 @@ class AccountApi extends ApiGroup {
       ...(sub.scheduledChangeAt
         ? { scheduledChangeAt: new Date(sub.scheduledChangeAt).toISOString() }
         : {}),
+      ...(sub.paymentPending ? { paymentPending: true } : {}),
       capabilities:
         sub.capabilities ??
         (data.active && (sub.tier === 'unlimited' || sub.tier === 'unlimited_pro')

--- a/src/Account/subscription.types.ts
+++ b/src/Account/subscription.types.ts
@@ -106,6 +106,13 @@ export interface SubscriptionEntitlementSnapshot {
   /** Feature flags or capability names enabled by this subscription. */
   capabilities?: Record<string, boolean>;
   /**
+   * True when a Google Play deferred payment (e.g. QRIS) is awaiting
+   * confirmation and there is no active entitlement yet. Display-only. Carried
+   * by the REST status snapshot; absent on older servers. Pairs with `active`:
+   * consumers should show a pending hint only while `paymentPending && !active`.
+   */
+  paymentPending?: boolean;
+  /**
    * Frontier vendor-model discount (basis points) this member currently
    * receives on the artist-facing price of premium third-party vendor models
    * (`gpt-image-2`, `seedance-2-0`, `seedance-2-0-fast`). Present only when the

--- a/src/ApiClient/WebSocketClient/events.ts
+++ b/src/ApiClient/WebSocketClient/events.ts
@@ -45,6 +45,12 @@ export interface SocketSubscriptionEntitlementData {
      * server. When absent the SDK derives a minimal local map.
      */
     capabilities?: Record<string, boolean> | null;
+    /**
+     * Whether a deferred payment is awaiting confirmation. Not emitted by the
+     * backend socket publisher today (the REST snapshot is the source); typed
+     * here so the mapper can pass it through if a future build adds it.
+     */
+    paymentPending?: boolean | null;
   } | null;
 }
 


### PR DESCRIPTION
## What & why

Adds an optional **`paymentPending?: boolean`** to `SubscriptionEntitlementSnapshot` so web consumers can read the backend's new field and show a non-blocking "payment pending" hint for a Google Play deferred payment (QRIS) awaiting confirmation. This is the **SDK link** in a 3-repo feature (backend: Sogni-AI/sogni-api#102; web banner follows).

The backend returns `paymentPending` on the REST `GET /v1/subscriptions/status` snapshot, which the SDK assigns through to `currentAccount.subscription` **untouched** — so adding the type is what makes the field typed/usable on the client. Consumers should treat it as display-only and show the hint only while `paymentPending && !active`.

## Changes

- `Account/subscription.types.ts` — `paymentPending?: boolean` on `SubscriptionEntitlementSnapshot` (additive, optional).
- `ApiClient/WebSocketClient/events.ts` — `paymentPending?: boolean | null` on the socket subscription payload (forward-compat; the backend socket publisher does not emit it today — the REST snapshot is the source).
- `Account/index.ts` — pass it through `mapSocketSubscriptionEntitlement` (`...(sub.paymentPending ? { paymentPending: true } : {})`).

## Verification

- `npm run build` clean; `npm run test:subscription-api` → ALL TESTS PASSED.
- Purely additive, **non-breaking** (a `feat` minor/prerelease bump is correct).

## Release note

Merging to `alpha` triggers semantic-release to publish a new `5.1.0-alpha.x`; the web app then bumps `@sogni-ai/sogni-client` to consume the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
