### PR TITLE
feat(telemetry): add agent attribution contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         run: npm audit signatures
       - name: Run subscription API checks (builds dist first)
         run: npm run test:subscription-api
+      - name: Run attribution transport checks
+        run: npm run test:attribution
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -157,6 +157,43 @@ await sogni.setSocketEventSubscriptions({
 
 Runtime subscription changes made via `setSocketEventSubscriptions` are remembered locally and re-applied on every reconnect, so a long-lived client only needs to express its preference once.
 
+Agent integrations can optionally declare connection and workload attribution without changing `appSource`. Defaults are immutable and per-request overrides are isolated, so concurrent operations cannot leak lineage into one another:
+
+```typescript
+const sogni = await SogniClient.createInstance({
+  appId: 'your-app-id',
+  appSource: 'my-agent-integration',
+  apiKey: 'your-api-key',
+  attribution: {
+    connection: {
+      interactionKind: 'external_agent',
+      agentFramework: 'codex',
+      agentSurface: 'plugin'
+    },
+    workload: {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'codex',
+      agentSurface: 'plugin',
+      executionMode: 'server'
+    }
+  }
+});
+
+await sogni.projects.create({
+  type: 'image',
+  modelId: 'z_image_turbo_bf16',
+  positivePrompt: 'A cinematic mountain observatory',
+  numberOfMedia: 1,
+  attribution: {
+    operationScope: 'child',
+    rootOperationId: 'turn-123',
+    parentOperationId: 'tool-call-456'
+  }
+});
+```
+
+The SDK supplies the project/job operation ID when it is omitted. Standalone attributed calls default to `top_level`; child calls should provide their stable root and immediate parent IDs. All attribution is optional, normalized again by the server, and excluded entirely from the wire for callers that do not configure it.
+
 ## Usage
 
 After authentication, the client will have an active WebSocket connection to Sogni Supernet. Within a short period of time the

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -254,6 +254,33 @@ const portal = await sogni.account.createSubscriptionPortalSession();
 
 `checkAuth()` is only for cookie-auth browser flows on permitted Sogni domains. API-key auth auto-authenticates during `createInstance()`. Username/password auth uses `sogni.account.login()`. Token auth can be resumed with `sogni.setTokens()`.
 
+AGENT ATTRIBUTION:
+
+Keep `appSource` as the stable product/integration identifier. Agent wrappers may add immutable `attribution.connection` and `attribution.workload` defaults:
+
+```typescript
+const sogni = await SogniClient.createInstance({
+  appId: 'my-agent',
+  appSource: 'my-agent-integration',
+  apiKey: process.env.SOGNI_API_KEY,
+  attribution: {
+    connection: {
+      interactionKind: 'external_agent',
+      agentFramework: 'codex',
+      agentSurface: 'plugin'
+    },
+    workload: {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'codex',
+      agentSurface: 'plugin',
+      executionMode: 'server'
+    }
+  }
+});
+```
+
+Project, socket chat, hosted chat/tool, durable chat run, and creative workflow calls accept an optional per-operation `attribution` override. Standalone attributed requests default to `operationScope: 'top_level'` and use the underlying project/job request ID. For child work, pass `operationScope: 'child'`, a stable `rootOperationId`, and the immediate `parentOperationId`; omit `operationId` to use the request's generated ID. The exported attribution types include `native_desktop`. Invalid metadata is dropped, the server remains authoritative, and all new wire fields are omitted when attribution is not configured.
+
 NETWORK TYPES:
 
 - 'fast': High-end GPU workers. Faster, higher cost. REQUIRED for video.

--- a/llms.txt
+++ b/llms.txt
@@ -140,6 +140,10 @@ const portal = await sogni.account.createSubscriptionPortalSession();
 
 Checkout and portal sessions require user authentication; API-key auth is rejected for those redirect operations.
 
+AGENT ATTRIBUTION:
+
+Keep `appSource` as the stable product/integration ID. Agent wrappers may additionally set immutable `attribution.connection` and `attribution.workload` defaults on `createInstance()`, then override `attribution` per project, socket/hosted/durable chat request, hosted tool, or creative workflow. Exported unions cover `interactionKind`, `workloadKind`, `agentSurface` (including `native_desktop`), `executionMode`, and operation lineage. Standalone attributed calls receive a top-level operation ID from the underlying job/request; child calls should provide `operationScope: 'child'`, `rootOperationId`, and `parentOperationId`. All fields are optional and omitted for legacy callers.
+
 ### Network Types
 
 - `fast` - High-end GPUs, faster, more expensive. **Required for video.**

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "prepublishOnly": "npm run build",
     "build": "npm run clean && npm run codegen && tsc --project tsconfig.json && tsc --project tsconfig.esm.json && node scripts/write-dist-esm-package-json.mjs",
     "test:chat-routing": "npm run build && node scripts/check-chat-model-routing.cjs",
+    "test:attribution": "npm run build && node scripts/check-attribution-transport.cjs",
     "test:subscription-api": "npm run build && node scripts/check-subscription-api.cjs",
     "test:workflow-template-envelope": "npm run build && node scripts/check-workflow-template-envelope.cjs",
     "watch": "npm run clean && npm run codegen && tsc --watch --project tsconfig.json",

--- a/scripts/check-attribution-transport.cjs
+++ b/scripts/check-attribution-transport.cjs
@@ -1,0 +1,584 @@
+const assert = require('node:assert/strict');
+
+const {
+  appendConnectionAttributionQuery,
+  buildSogniAttributionHeaders,
+  normalizeConnectionAttribution,
+  resolveWorkloadAttribution,
+  workloadAttributionToWireFields
+} = require('../dist/lib/attribution.js');
+const ApiClient = require('../dist/ApiClient/index.js').default;
+const ChatApi = require('../dist/Chat/index.js').default;
+const CreativeWorkflowsApi = require('../dist/CreativeWorkflows/index.js').default;
+const ProjectsApi = require('../dist/Projects/index.js').default;
+
+class StubSocket {
+  constructor() {
+    this.sent = [];
+  }
+
+  on() {
+    return () => {};
+  }
+
+  async send(type, data) {
+    this.sent.push({ type, data });
+  }
+}
+
+class StubClient {
+  constructor({ appSource, connection, workload } = {}) {
+    this.appSource = appSource;
+    this.attribution = {
+      ...(connection ? { connection: normalizeConnectionAttribution(connection) } : {}),
+      ...(workload ? { workload } : {})
+    };
+    this.socket = new StubSocket();
+    this.restCalls = [];
+    this.rest = {
+      baseUrl: 'https://api.example.test',
+      post: async (path, body, options) => {
+        this.restCalls.push({ path, body, options });
+        return {
+          id: 'chatcmpl-test',
+          object: 'chat.completion',
+          created: 1,
+          model: body.model || 'test',
+          choices: []
+        };
+      },
+      get: async () => ({
+        status: 'success',
+        data: { uploadUrl: 'https://storage.example.test/presigned' }
+      })
+    };
+    this.auth = {
+      isAuthenticated: true,
+      authenticateRequest: async (options) => options,
+      clear: () => {}
+    };
+    this.logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+  }
+
+  on() {
+    return () => {};
+  }
+
+  resolveWorkloadAttribution(override, fallbackOperationId) {
+    return resolveWorkloadAttribution(
+      this.attribution.workload,
+      override,
+      fallbackOperationId
+    );
+  }
+
+  attributionHeaders(appSource, override, fallbackOperationId) {
+    return buildSogniAttributionHeaders({
+      appSource,
+      connection: this.attribution.connection,
+      workload: this.resolveWorkloadAttribution(override, fallbackOperationId)
+    });
+  }
+}
+
+const IMAGE_MODEL_OPTIONS = {
+  type: 'image',
+  steps: { min: 1, max: 100, step: 1, default: 20 },
+  guidance: { min: 0, max: 20, step: 0.1, default: 7.5 },
+  scheduler: { allowed: [], default: null },
+  sampler: { allowed: [], default: null }
+};
+
+const LOGGER = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {}
+};
+
+function headerRecord(headers) {
+  if (!headers) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  return { ...headers };
+}
+
+function assertNoSogniTelemetryHeaders(headers) {
+  const names = Object.keys(headerRecord(headers)).map((name) => name.toLowerCase());
+  assert.equal(
+    names.some((name) => name.startsWith('x-sogni-')),
+    false,
+    `unexpected telemetry header in ${names.join(', ')}`
+  );
+}
+
+async function checkHelpers() {
+  const connection = normalizeConnectionAttribution({
+    interactionKind: 'external_agent',
+    agentFramework: ' codex ',
+    agentFrameworkVersion: ' 1.2.3 ',
+    agentSurface: 'native_desktop',
+    agentSurfaceVersion: ' 5.0 ',
+    executionMode: 'server'
+  });
+  const url = new URL('wss://socket.example.test/connect');
+  appendConnectionAttributionQuery(url, connection);
+  assert.deepEqual(Object.fromEntries(url.searchParams), {
+    interactionKind: 'external_agent',
+    agentFramework: 'codex',
+    agentFrameworkVersion: '1.2.3',
+    agentSurface: 'native_desktop',
+    agentSurfaceVersion: '5.0',
+    executionMode: 'server'
+  });
+
+  const untouched = new URL('wss://socket.example.test/connect');
+  appendConnectionAttributionQuery(untouched, undefined);
+  assert.equal(untouched.search, '');
+
+  const resolved = resolveWorkloadAttribution(
+    {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'codex',
+      agentFrameworkVersion: '1.2.3',
+      agentSurface: 'plugin',
+      agentSurfaceVersion: '4.5.6',
+      executionMode: 'server'
+    },
+    {
+      agentFramework: 'claude-code',
+      agentFrameworkVersion: '2.0.0',
+      operationScope: 'child',
+      rootOperationId: 'ROOT',
+      parentOperationId: 'PARENT'
+    },
+    'JOB'
+  );
+  assert.deepEqual(resolved, {
+    workloadKind: 'agent_mediated',
+    agentFramework: 'claude-code',
+    agentFrameworkVersion: '2.0.0',
+    agentSurface: 'plugin',
+    agentSurfaceVersion: '4.5.6',
+    executionMode: 'server',
+    operationScope: 'child',
+    operationId: 'JOB',
+    rootOperationId: 'ROOT',
+    parentOperationId: 'PARENT'
+  });
+  assert.deepEqual(workloadAttributionToWireFields(resolved), resolved);
+
+  const frameworkWithoutVersion = resolveWorkloadAttribution(
+    {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'codex',
+      agentFrameworkVersion: '1.2.3'
+    },
+    { agentFramework: 'openclaw' },
+    'NO-STALE-VERSION'
+  );
+  assert.equal(frameworkWithoutVersion.agentFramework, 'openclaw');
+  assert.equal(frameworkWithoutVersion.agentFrameworkVersion, undefined);
+
+  const manualOverride = resolveWorkloadAttribution(
+    {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'sogni-studio',
+      agentFrameworkVersion: '5.0.0',
+      agentSurface: 'native_desktop'
+    },
+    { workloadKind: 'direct' },
+    'MANUAL-STUDIO-JOB'
+  );
+  assert.equal(manualOverride.workloadKind, 'direct');
+  assert.equal(manualOverride.agentFramework, undefined);
+  assert.equal(manualOverride.agentFrameworkVersion, undefined);
+  assert.equal(manualOverride.agentSurface, 'native_desktop');
+
+  const topLevel = resolveWorkloadAttribution(
+    { workloadKind: 'direct', agentSurface: 'sdk' },
+    undefined,
+    'TOP'
+  );
+  assert.equal(topLevel.operationScope, 'top_level');
+  assert.equal(topLevel.operationId, 'TOP');
+  assert.equal(topLevel.rootOperationId, 'TOP');
+  assert.equal(topLevel.parentOperationId, undefined);
+
+  const explicitTopLevel = resolveWorkloadAttribution(
+    { workloadKind: 'agent_mediated', agentFramework: 'sogni-chat' },
+    { operationScope: 'top_level', operationId: 'USER-TURN' },
+    'TRANSPORT-JOB'
+  );
+  assert.equal(explicitTopLevel.operationId, 'USER-TURN');
+  assert.equal(explicitTopLevel.rootOperationId, 'USER-TURN');
+
+  const childWithRoot = resolveWorkloadAttribution(
+    { workloadKind: 'agent_mediated', agentFramework: 'sogni-chat' },
+    { operationScope: 'child', rootOperationId: 'TURN' },
+    'CHILD'
+  );
+  assert.equal(childWithRoot.parentOperationId, 'TURN');
+
+  const clearedMetadata = resolveWorkloadAttribution(
+    { workloadKind: 'agent_mediated', agentFramework: 'codex' },
+    { agentFramework: ' ' },
+    'CLEARED'
+  );
+  assert.equal(clearedMetadata.agentFramework, undefined);
+
+  assert.equal(
+    resolveWorkloadAttribution(
+      undefined,
+      {
+        workloadKind: 'not-valid',
+        agentFramework: '\r\n',
+        agentSurface: 'also-invalid',
+        operationId: 'x'.repeat(300)
+      },
+      'SHOULD-NOT-CREATE-ATTRIBUTION'
+    ),
+    undefined
+  );
+  assert.deepEqual(workloadAttributionToWireFields(undefined), {});
+
+  const headers = buildSogniAttributionHeaders({
+    appSource: ' sogni-chat ',
+    connection,
+    workload: resolved
+  });
+  assert.equal(headers['X-App-Source'], 'sogni-chat');
+  assert.equal(headers['X-Sogni-Interaction-Kind'], 'external_agent');
+  assert.equal(headers['X-Sogni-Agent-Framework'], 'claude-code');
+  assert.equal(headers['X-Sogni-Agent-Framework-Version'], '2.0.0');
+  assert.equal(headers['X-Sogni-Agent-Surface-Version'], '4.5.6');
+  assert.equal(headers['X-Sogni-Operation-Id'], 'JOB');
+  assert.equal(headers['X-Sogni-Root-Operation-Id'], 'ROOT');
+
+  const configuredWorkload = {
+    workloadKind: 'agent_mediated',
+    agentFramework: 'codex',
+    agentSurface: 'sdk'
+  };
+  const apiClient = new ApiClient({
+    baseUrl: 'https://api.example.test',
+    socketUrl: 'wss://socket.example.test',
+    appId: 'attribution-test',
+    appSource: 'agent-test',
+    attribution: {
+      connection: {
+        interactionKind: 'external_agent',
+        agentFramework: 'codex',
+        agentSurface: 'sdk'
+      },
+      workload: configuredWorkload
+    },
+    networkType: 'fast',
+    logger: LOGGER,
+    authType: 'token',
+    disableSocket: true
+  });
+  configuredWorkload.agentFramework = 'mutated-after-construction';
+  assert.equal(apiClient.attribution.workload.agentFramework, 'codex');
+  assert.ok(Object.isFrozen(apiClient.attribution));
+  assert.ok(Object.isFrozen(apiClient.attribution.workload));
+  const concurrentA = apiClient.resolveWorkloadAttribution(
+    { operationScope: 'child', rootOperationId: 'ROOT-A', parentOperationId: 'PARENT-A' },
+    'JOB-A'
+  );
+  const concurrentB = apiClient.resolveWorkloadAttribution(
+    { operationScope: 'child', rootOperationId: 'ROOT-B', parentOperationId: 'PARENT-B' },
+    'JOB-B'
+  );
+  assert.equal(concurrentA.rootOperationId, 'ROOT-A');
+  assert.equal(concurrentB.rootOperationId, 'ROOT-B');
+  assert.equal(apiClient.attribution.workload.rootOperationId, undefined);
+
+  const realFetch = globalThis.fetch;
+  let ownedRestRequest;
+  globalThis.fetch = async (url, init) => {
+    ownedRestRequest = { url: String(url), init };
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  };
+  try {
+    await apiClient.rest.post(
+      '/v1/owned-operation',
+      {},
+      {
+        headers: apiClient.attributionHeaders(
+          'agent-test',
+          { executionMode: 'server' },
+          'REST-JOB'
+        )
+      }
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  const ownedHeaders = headerRecord(ownedRestRequest.init.headers);
+  assert.equal(ownedHeaders['Content-Type'], 'application/json');
+  assert.equal(ownedHeaders['X-App-Source'], 'agent-test');
+  assert.equal(ownedHeaders['X-Sogni-Operation-Id'], 'REST-JOB');
+  apiClient.dispose();
+}
+
+async function checkSocketPayloads() {
+  const client = new StubClient({
+    appSource: 'sogni-agent-test',
+    connection: { interactionKind: 'external_agent', agentSurface: 'sdk' },
+    workload: {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'codex',
+      agentSurface: 'sdk',
+      executionMode: 'server'
+    }
+  });
+  const chat = new ChatApi({ client, eip712: {} });
+  await chat.completions.create({
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: true,
+    attribution: {
+      agentFramework: 'claude-code',
+      operationScope: 'child',
+      rootOperationId: 'ROOT',
+      parentOperationId: 'PARENT'
+    }
+  });
+  const sent = client.socket.sent.at(-1);
+  assert.equal(sent.type, 'llmJobRequest');
+  assert.equal(sent.data.workloadKind, 'agent_mediated');
+  assert.equal(sent.data.agentFramework, 'claude-code');
+  assert.equal(sent.data.agentSurface, 'sdk');
+  assert.equal(sent.data.operationScope, 'child');
+  assert.equal(sent.data.operationId, sent.data.jobID);
+  assert.equal(sent.data.rootOperationId, 'ROOT');
+  assert.equal(sent.data.parentOperationId, 'PARENT');
+  assert.equal('attribution' in sent.data, false);
+
+  const autoLogical = client.resolveWorkloadAttribution(
+    { operationScope: 'top_level', operationId: 'AUTO-ROOT' },
+    'IGNORED'
+  );
+  const autoRoot = chat.createAutoToolChildAttribution(autoLogical);
+  const autoRoundA = client.resolveWorkloadAttribution(autoRoot, 'AUTO-JOB-A');
+  const autoRoundB = client.resolveWorkloadAttribution(autoRoot, 'AUTO-JOB-B');
+  assert.equal(autoRoundA.operationScope, 'child');
+  assert.equal(autoRoundA.rootOperationId, autoRoundB.rootOperationId);
+  assert.equal(autoRoundA.parentOperationId, 'AUTO-ROOT');
+  assert.equal(autoRoundA.operationId, 'AUTO-JOB-A');
+  assert.equal(autoRoundB.operationId, 'AUTO-JOB-B');
+
+  const nestedAuto = chat.createAutoToolChildAttribution({
+    operationId: 'NESTED-LOGICAL',
+    operationScope: 'child',
+    rootOperationId: 'OUTER-ROOT',
+    parentOperationId: 'OUTER-PARENT'
+  });
+  assert.equal(nestedAuto.rootOperationId, 'OUTER-ROOT');
+  assert.equal(nestedAuto.parentOperationId, 'NESTED-LOGICAL');
+
+  const projects = new ProjectsApi({ client, eip712: {} });
+  projects.getModelOptions = async () => IMAGE_MODEL_OPTIONS;
+  const project = await projects.create({
+    type: 'image',
+    modelId: 'test-image',
+    positivePrompt: 'test',
+    numberOfMedia: 1,
+    attribution: {
+      agentFramework: 'openclaw',
+      operationScope: 'child',
+      rootOperationId: 'ROOT',
+      parentOperationId: 'TOOL'
+    }
+  });
+  const projectRequest = client.socket.sent.at(-1);
+  assert.equal(projectRequest.type, 'jobRequest');
+  assert.equal(projectRequest.data.agentFramework, 'openclaw');
+  assert.equal(projectRequest.data.operationId, project.id);
+  assert.equal(projectRequest.data.rootOperationId, 'ROOT');
+  assert.equal('attribution' in projectRequest.data, false);
+  project._update({
+    status: 'failed',
+    error: { code: 0, message: 'test cleanup' }
+  });
+
+  const legacyClient = new StubClient({ appSource: 'legacy-app' });
+  const legacyChat = new ChatApi({ client: legacyClient, eip712: {} });
+  await legacyChat.completions.create({
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: true
+  });
+  const legacy = legacyClient.socket.sent.at(-1).data;
+  for (const field of [
+    'workloadKind',
+    'agentFramework',
+    'agentFrameworkVersion',
+    'agentSurface',
+    'agentSurfaceVersion',
+    'executionMode',
+    'operationScope',
+    'operationId',
+    'rootOperationId',
+    'parentOperationId'
+  ]) {
+    assert.equal(field in legacy, false, `legacy socket payload unexpectedly included ${field}`);
+  }
+  assert.equal(legacy.appSource, 'legacy-app');
+}
+
+async function checkRestHeaders() {
+  const client = new StubClient({
+    appSource: 'sogni-chat',
+    connection: { interactionKind: 'human_ui', agentSurface: 'native_web' },
+    workload: {
+      workloadKind: 'agent_mediated',
+      agentFramework: 'sogni-chat',
+      agentSurface: 'native_web'
+    }
+  });
+  const chat = new ChatApi({ client, eip712: {} });
+
+  await chat.hosted.create({
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'hello' }],
+    attribution: { executionMode: 'browser' }
+  });
+  let call = client.restCalls.at(-1);
+  let headers = headerRecord(call.options.headers);
+  assert.equal(call.body.app_source, 'sogni-chat');
+  assert.equal('attribution' in call.body, false);
+  assert.equal(headers['X-App-Source'], 'sogni-chat');
+  assert.equal(headers['X-Sogni-Interaction-Kind'], 'human_ui');
+  assert.equal(headers['X-Sogni-Agent-Framework'], 'sogni-chat');
+  assert.equal(headers['X-Sogni-Execution-Mode'], 'browser');
+  assert.equal(headers['X-Sogni-Operation-Scope'], 'top_level');
+  assert.equal(headers['X-Sogni-Operation-Id'], headers['X-Sogni-Root-Operation-Id']);
+
+  await chat.hosted.executeTool({
+    tool: 'enhance_prompt',
+    arguments: { prompt: 'hello' },
+    attribution: {
+      agentFramework: 'hermes-agent',
+      operationScope: 'child',
+      rootOperationId: 'ROOT',
+      parentOperationId: 'PARENT'
+    }
+  });
+  call = client.restCalls.at(-1);
+  headers = headerRecord(call.options.headers);
+  assert.equal('attribution' in call.body, false);
+  assert.equal(headers['X-Sogni-Agent-Framework'], 'hermes-agent');
+  assert.equal(headers['X-Sogni-Operation-Scope'], 'child');
+  assert.equal(headers['X-Sogni-Root-Operation-Id'], 'ROOT');
+
+  const realFetch = globalThis.fetch;
+  const fetchCalls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    fetchCalls.push({ url: String(url), init });
+    return new Response(
+      JSON.stringify({
+        status: 'success',
+        data: {
+          run: { runId: 'run-test' },
+          workflow: { workflowId: 'workflow-test' },
+          resumed: true,
+          reseed: { cloned_from_run_id: 'workflow-old', steps: [] }
+        }
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  try {
+    await chat.runs.create({
+      messages: [{ role: 'user', content: 'hello' }],
+      attribution: { executionMode: 'durable' }
+    });
+    let fetchCall = fetchCalls.at(-1);
+    headers = headerRecord(fetchCall.init.headers);
+    assert.equal('attribution' in JSON.parse(fetchCall.init.body), false);
+    assert.equal(headers['X-Sogni-Execution-Mode'], 'durable');
+    assert.equal(headers['X-Sogni-Agent-Framework'], 'sogni-chat');
+
+    const workflows = new CreativeWorkflowsApi({ client, eip712: {} });
+    await workflows.start({
+      input: { steps: [] },
+      attribution: { agentFramework: 'codex', executionMode: 'server' }
+    });
+    fetchCall = fetchCalls.at(-1);
+    headers = headerRecord(fetchCall.init.headers);
+    assert.equal('attribution' in JSON.parse(fetchCall.init.body), false);
+    assert.equal(headers['X-App-Source'], 'sogni-chat');
+    assert.equal(headers['X-Sogni-Agent-Framework'], 'codex');
+    assert.equal(headers['X-Sogni-Operation-Scope'], 'top_level');
+
+    await workflows.resume('workflow-test', {
+      attribution: {
+        operationScope: 'child',
+        rootOperationId: 'ROOT',
+        parentOperationId: 'PARENT'
+      }
+    });
+    fetchCall = fetchCalls.at(-1);
+    headers = headerRecord(fetchCall.init.headers);
+    assert.equal(headers['X-Sogni-Operation-Scope'], 'child');
+    assert.equal(headers['X-Sogni-Root-Operation-Id'], 'ROOT');
+
+    await workflows.reseed('workflow-test', {
+      attribution: { agentFramework: 'openclaw' }
+    });
+    fetchCall = fetchCalls.at(-1);
+    headers = headerRecord(fetchCall.init.headers);
+    assert.equal(headers['X-Sogni-Agent-Framework'], 'openclaw');
+
+    // Presigned third-party uploads must receive only storage-required headers,
+    // even when the owning Sogni client has attribution defaults.
+    const projects = new ProjectsApi({ client, eip712: {} });
+    await projects.uploadGuideImage('PROJECT', new Blob(['image'], { type: 'image/png' }));
+    fetchCall = fetchCalls.at(-1);
+    assert.equal(fetchCall.url, 'https://storage.example.test/presigned');
+    assert.equal(fetchCall.init.method, 'PUT');
+    assertNoSogniTelemetryHeaders(fetchCall.init.headers);
+    assert.equal(
+      Object.keys(headerRecord(fetchCall.init.headers)).some(
+        (name) => name.toLowerCase() === 'x-app-source'
+      ),
+      false
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+
+  const legacyClient = new StubClient({ appSource: 'legacy-app' });
+  const legacyChat = new ChatApi({ client: legacyClient, eip712: {} });
+  await legacyChat.hosted.create({
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'hello' }]
+  });
+  const legacyHeaders = headerRecord(legacyClient.restCalls.at(-1).options.headers);
+  assert.equal(legacyHeaders['X-App-Source'], 'legacy-app');
+  assertNoSogniTelemetryHeaders(legacyHeaders);
+}
+
+async function run() {
+  await checkHelpers();
+  await checkSocketPayloads();
+  await checkRestHeaders();
+  console.log('check-attribution-transport: OK');
+}
+
+run().catch((error) => {
+  console.error('check-attribution-transport: FAIL');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/ApiClient/WebSocketClient/BrowserWebSocketClient/index.ts
+++ b/src/ApiClient/WebSocketClient/BrowserWebSocketClient/index.ts
@@ -14,6 +14,7 @@ import type {
   SocketEventSubscriptionInput,
   SocketEventSubscriptions
 } from '../eventSubscriptions.js';
+import type { NormalizedConnectionAttribution } from '../../../lib/attribution.js';
 
 interface SocketSend<T extends MessageType = MessageType> {
   type: 'socket-send';
@@ -114,7 +115,8 @@ class BrowserWebSocketClient extends RestClient<SocketEventMap> implements IWebS
     supernetType: SupernetType,
     logger: Logger,
     appSource?: string,
-    socketEventSubscriptions?: SocketEventSubscriptions
+    socketEventSubscriptions?: SocketEventSubscriptions,
+    connectionAttribution?: NormalizedConnectionAttribution
   ) {
     const socketClient = new WrappedClient(
       baseUrl,
@@ -123,7 +125,8 @@ class BrowserWebSocketClient extends RestClient<SocketEventMap> implements IWebS
       supernetType,
       logger,
       appSource,
-      socketEventSubscriptions
+      socketEventSubscriptions,
+      connectionAttribution
     );
     super(socketClient.baseUrl, auth, logger);
     this.socketClient = socketClient;

--- a/src/ApiClient/WebSocketClient/index.ts
+++ b/src/ApiClient/WebSocketClient/index.ts
@@ -16,6 +16,11 @@ import type {
   SocketEventSubscriptionInput,
   SocketEventSubscriptions
 } from './eventSubscriptions.js';
+import {
+  appendConnectionAttributionQuery,
+  normalizeConnectionAttribution,
+  type NormalizedConnectionAttribution
+} from '../../lib/attribution.js';
 
 const PROTOCOL_VERSION = '3.0.0';
 
@@ -24,6 +29,7 @@ const PING_INTERVAL = 15000;
 class WebSocketClient extends RestClient<SocketEventMap> implements IWebSocketClient {
   appId: string;
   appSource?: string;
+  connectionAttribution?: NormalizedConnectionAttribution;
   baseUrl: string;
   socketEventSubscriptions?: SocketEventSubscriptions;
   private socket: WebSocket | null = null;
@@ -37,7 +43,8 @@ class WebSocketClient extends RestClient<SocketEventMap> implements IWebSocketCl
     supernetType: SupernetType,
     logger: Logger,
     appSource?: string,
-    socketEventSubscriptions?: SocketEventSubscriptions
+    socketEventSubscriptions?: SocketEventSubscriptions,
+    connectionAttribution?: NormalizedConnectionAttribution
   ) {
     const _baseUrl = new URL(baseUrl);
     switch (_baseUrl.protocol) {
@@ -55,6 +62,7 @@ class WebSocketClient extends RestClient<SocketEventMap> implements IWebSocketCl
     super(_baseUrl.toString(), auth, logger);
     this.appId = appId;
     this.appSource = appSource?.trim() || undefined;
+    this.connectionAttribution = normalizeConnectionAttribution(connectionAttribution);
     this.socketEventSubscriptions = socketEventSubscriptions;
     this.baseUrl = _baseUrl.toString();
     this._supernetType = supernetType;
@@ -87,6 +95,7 @@ class WebSocketClient extends RestClient<SocketEventMap> implements IWebSocketCl
     if (this.appSource) {
       url.searchParams.set('appSource', this.appSource);
     }
+    appendConnectionAttributionQuery(url, this.connectionAttribution);
     const socketEventSubscriptions = serializeSocketEventSubscriptions(
       this.socketEventSubscriptions
     );

--- a/src/ApiClient/index.ts
+++ b/src/ApiClient/index.ts
@@ -16,6 +16,17 @@ import CookieAuthManager from '../lib/AuthManager/CookieAuthManager.js';
 import { AuthManager, TokenAuthManager } from '../lib/AuthManager/index.js';
 import isNodejs from '../lib/isNodejs.js';
 import BrowserWebSocketClient from './WebSocketClient/BrowserWebSocketClient/index.js';
+import {
+  buildSogniAttributionHeaders,
+  normalizeConnectionAttribution,
+  resolveWorkloadAttribution,
+  type NormalizedConnectionAttribution
+} from '../lib/attribution.js';
+import type {
+  SogniAttributionConfig,
+  WorkloadAttributionDefaults,
+  WorkloadAttributionInput
+} from '../types/attribution.js';
 
 const WS_RECONNECT_ATTEMPTS = 5;
 
@@ -46,6 +57,7 @@ export interface ApiClientOptions {
   socketUrl: string;
   appId: string;
   appSource?: string;
+  attribution?: SogniAttributionConfig;
   socketEventSubscriptions?: SocketEventSubscriptions;
   networkType: SupernetType;
   logger: Logger;
@@ -57,6 +69,10 @@ export interface ApiClientOptions {
 class ApiClient extends TypedEventEmitter<ApiClientEvents> {
   readonly appId: string;
   readonly appSource?: string;
+  readonly attribution: Readonly<{
+    connection?: Readonly<NormalizedConnectionAttribution>;
+    workload?: Readonly<WorkloadAttributionDefaults>;
+  }>;
   readonly logger: Logger;
   private _rest: RestClient;
   private _socket: IWebSocketClient;
@@ -69,6 +85,7 @@ class ApiClient extends TypedEventEmitter<ApiClientEvents> {
     socketUrl,
     appId,
     appSource,
+    attribution,
     socketEventSubscriptions,
     networkType,
     authType,
@@ -79,6 +96,11 @@ class ApiClient extends TypedEventEmitter<ApiClientEvents> {
     super();
     this.appId = appId;
     this.appSource = appSource?.trim() || undefined;
+    const connectionAttribution = normalizeConnectionAttribution(attribution?.connection);
+    this.attribution = Object.freeze({
+      ...(connectionAttribution ? { connection: Object.freeze(connectionAttribution) } : {}),
+      ...(attribution?.workload ? { workload: Object.freeze({ ...attribution.workload }) } : {})
+    });
     this.logger = logger;
     if (authType === 'apiKey') {
       this._auth = new ApiKeyAuthManager(logger);
@@ -98,7 +120,8 @@ class ApiClient extends TypedEventEmitter<ApiClientEvents> {
         networkType,
         logger,
         this.appSource,
-        socketEventSubscriptions
+        socketEventSubscriptions,
+        this.attribution.connection
       );
     } else {
       this._socket = new WebSocketClient(
@@ -108,7 +131,8 @@ class ApiClient extends TypedEventEmitter<ApiClientEvents> {
         networkType,
         logger,
         this.appSource,
-        socketEventSubscriptions
+        socketEventSubscriptions,
+        this.attribution.connection
       );
     }
     this._disableSocket = disableSocket;
@@ -135,6 +159,22 @@ class ApiClient extends TypedEventEmitter<ApiClientEvents> {
 
   get socketEnabled(): boolean {
     return !this._disableSocket;
+  }
+
+  resolveWorkloadAttribution(override?: WorkloadAttributionInput, fallbackOperationId?: string) {
+    return resolveWorkloadAttribution(this.attribution.workload, override, fallbackOperationId);
+  }
+
+  attributionHeaders(
+    appSource: string | undefined,
+    override?: WorkloadAttributionInput,
+    fallbackOperationId?: string
+  ): Record<string, string> {
+    return buildSogniAttributionHeaders({
+      appSource,
+      connection: this.attribution.connection,
+      workload: this.resolveWorkloadAttribution(override, fallbackOperationId)
+    });
   }
 
   setSocketEventSubscriptions(update: SocketEventSubscriptionInput): Promise<void> {

--- a/src/ApiGroup.ts
+++ b/src/ApiGroup.ts
@@ -1,6 +1,8 @@
 import ApiClient from './ApiClient/index.js';
 import EIP712Helper from './lib/EIP712Helper.js';
 import TypedEventEmitter, { EventMap } from './lib/TypedEventEmitter.js';
+import { buildSogniAttributionHeaders, resolveWorkloadAttribution } from './lib/attribution.js';
+import type { WorkloadAttributionInput } from './types/attribution.js';
 
 export interface ApiConfig {
   client: ApiClient;
@@ -15,6 +17,29 @@ abstract class ApiGroup<E extends EventMap = {}> extends TypedEventEmitter<E> {
     super();
     this.client = config.client;
     this.eip712 = config.eip712;
+  }
+
+  protected resolveWorkloadAttribution(
+    override?: WorkloadAttributionInput,
+    fallbackOperationId?: string
+  ) {
+    return resolveWorkloadAttribution(
+      this.client.attribution?.workload,
+      override,
+      fallbackOperationId
+    );
+  }
+
+  protected attributionHeaders(
+    appSource: string | undefined,
+    override?: WorkloadAttributionInput,
+    fallbackOperationId?: string
+  ): Record<string, string> {
+    return buildSogniAttributionHeaders({
+      appSource,
+      connection: this.client.attribution?.connection,
+      workload: this.resolveWorkloadAttribution(override, fallbackOperationId)
+    });
   }
 }
 

--- a/src/Chat/ChatTools.ts
+++ b/src/Chat/ChatTools.ts
@@ -155,6 +155,7 @@ class ChatToolsApi {
           tokenType: options?.tokenType,
           network: options?.network,
           numberOfMedia: options?.numberOfMedia,
+          attribution: options?.attribution,
           timeout: options?.timeout,
           onProgress: options?.onToolProgress
             ? (progress: ToolExecutionProgress) => options.onToolProgress!(toolCall, progress)
@@ -213,7 +214,10 @@ class ChatToolsApi {
   ): Promise<ToolExecutionResult> {
     options?.onProgress?.({ status: 'creating', percent: 0 });
 
-    const project = await this.projects.create(projectParams as any);
+    const project = await this.projects.create({
+      ...projectParams,
+      ...(options?.attribution ? { attribution: options.attribution } : {})
+    } as any);
     const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let jobsCompleted = 0;

--- a/src/Chat/index.ts
+++ b/src/Chat/index.ts
@@ -34,6 +34,8 @@ import {
 import getUUID from '../lib/getUUID.js';
 import type ProjectsApi from '../Projects/index.js';
 import { mediaInputToInlineDataUri } from '../lib/mediaValidation.js';
+import { workloadAttributionToWireFields } from '../lib/attribution.js';
+import type { WorkloadAttributionInput } from '../types/attribution.js';
 
 const MAX_VISION_IMAGE_COUNT = 20;
 const MAX_VISION_IMAGE_BYTES = 10 * 1024 * 1024;
@@ -510,13 +512,15 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
     const normalizedMessages = await normalizeVisionMessages(params.messages);
     const chatTemplateKwargs =
       params.chat_template_kwargs ?? this.buildChatTemplateKwargs(params.think);
+    const appSource = params.app_source ?? params.appSource ?? this.client.appSource;
+    const attributionHeaders = this.attributionHeaders(appSource, params.attribution, getUUID());
     try {
       return await this.client.rest.post<HostedChatCompletionResult>(
         '/v1/chat/completions',
         {
           model: params.model,
           messages: normalizedMessages,
-          app_source: params.app_source ?? params.appSource ?? this.client.appSource,
+          app_source: appSource,
           max_tokens: params.max_tokens,
           temperature: params.temperature,
           top_p: params.top_p,
@@ -541,7 +545,7 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
           ...(chatTemplateKwargs && { chat_template_kwargs: chatTemplateKwargs }),
           ...(params.response_format && { response_format: params.response_format })
         },
-        { timeoutMs: 300000 }
+        { timeoutMs: 300000, headers: attributionHeaders }
       );
     } catch (error) {
       // Re-throw recognized chat-job error bodies (e.g. subscription
@@ -569,18 +573,22 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
   private async executeHostedTool(
     params: HostedToolExecutionParams
   ): Promise<HostedToolExecutionResult> {
+    const appSource = params.app_source ?? params.appSource ?? this.client.appSource;
     return this.client.rest.post<HostedToolExecutionResult>(
       '/v1/creative-agent/tools/execute',
       {
         tool: params.tool,
         arguments: params.arguments,
-        app_source: params.app_source ?? params.appSource ?? this.client.appSource,
+        app_source: appSource,
         token_type: params.token_type ?? params.tokenType,
         ...(params.safe_content_filter !== undefined || params.safeContentFilter !== undefined
           ? { safe_content_filter: params.safe_content_filter ?? params.safeContentFilter }
           : {})
       },
-      { timeoutMs: 300000 }
+      {
+        timeoutMs: 300000,
+        headers: this.attributionHeaders(appSource, params.attribution, getUUID())
+      }
     );
   }
 
@@ -633,6 +641,7 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
   private async createChatRun(params: StartChatRunParams): Promise<ChatRunRecord> {
     assertChatRunUsesExternalMedia(params);
     const appSource = params.appSource ?? this.client.appSource;
+    const operationId = getUUID();
     const body: Record<string, unknown> = {
       messages: params.messages,
       ...(params.tools ? { tools: params.tools } : {}),
@@ -652,7 +661,10 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
       ...(appSource ? { app_source: appSource } : {}),
       ...(params.runtimeConfig ? { runtime_config: params.runtimeConfig } : {})
     };
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.attributionHeaders(appSource, params.attribution, operationId)
+    };
     if (params.idempotencyKey) headers['Idempotency-Key'] = params.idempotencyKey;
     const response = await this.chatRunJson<{
       status: string;
@@ -828,7 +840,8 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
       sogni_tool_execution: params.sogni_tool_execution,
       taskProfile: params.taskProfile,
       ...(chatTemplateKwargs && { chat_template_kwargs: chatTemplateKwargs }),
-      ...(params.response_format && { response_format: params.response_format })
+      ...(params.response_format && { response_format: params.response_format }),
+      ...workloadAttributionToWireFields(this.resolveWorkloadAttribution(params.attribution, jobID))
     };
 
     const stream = new ChatStream(jobID);
@@ -891,13 +904,18 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
     const maxRounds = params.maxToolRounds || 5;
     const toolHistory: ToolHistoryEntry[] = [];
     let messages = [...params.messages];
+    const logicalOperation = this.resolveWorkloadAttribution(params.attribution, getUUID());
+    const autoToolChildAttribution = this.createAutoToolChildAttribution(logicalOperation);
 
     for (let round = 0; round < maxRounds; round++) {
       const result = (await this.createSingleCompletion({
         ...params,
         messages,
         stream: false,
-        autoExecuteTools: false
+        autoExecuteTools: false,
+        // The first LLM admission represents the logical auto-tool request.
+        // Later rounds and tool/media work are compute children of that root.
+        attribution: round === 0 ? logicalOperation : autoToolChildAttribution
       })) as ChatCompletionResult;
 
       // If model didn't request tools, return final result
@@ -911,6 +929,7 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
       // Execute tool calls
       const toolResults = await this.tools.executeAll(result.tool_calls, {
         tokenType: params.tokenType,
+        attribution: autoToolChildAttribution,
         onToolCall: params.onToolCall,
         onToolProgress: params.onToolProgress
       });
@@ -940,6 +959,26 @@ class ChatApi extends ApiGroup<ChatApiEvents> {
     }
 
     throw new Error(`Max tool calling rounds (${maxRounds}) exceeded`);
+  }
+
+  /**
+   * Build attribution for compute spawned by one logical auto-tool operation.
+   * Each child receives its own transport operation ID while retaining the
+   * logical operation as its immediate parent.
+   */
+  private createAutoToolChildAttribution(
+    attribution: WorkloadAttributionInput | undefined
+  ): WorkloadAttributionInput | undefined {
+    const logicalOperation = this.resolveWorkloadAttribution(attribution, getUUID());
+    if (!logicalOperation?.operationId) return undefined;
+    const rootOperationId = logicalOperation.rootOperationId ?? logicalOperation.operationId;
+    return {
+      ...logicalOperation,
+      operationScope: 'child',
+      operationId: undefined,
+      rootOperationId,
+      parentOperationId: logicalOperation.operationId
+    };
   }
 
   private handleJobTokens(data: JobTokensData): void {

--- a/src/Chat/types.ts
+++ b/src/Chat/types.ts
@@ -1,4 +1,5 @@
 import type { BillingMode } from '../Projects/types/index.js';
+import type { WorkloadAttributionInput } from '../types/attribution.js';
 
 export interface ToolFunction {
   name: string;
@@ -96,6 +97,8 @@ export interface ChatCompletionParams {
   messages: ChatMessage[];
   /** Optional source label for this request. Defaults to the client appSource when configured. */
   appSource?: string;
+  /** Optional workload attribution overriding this client's defaults. */
+  attribution?: WorkloadAttributionInput;
   max_tokens?: number;
   temperature?: number;
   top_p?: number;
@@ -181,7 +184,7 @@ export interface ChatCompletionParams {
   maxToolRounds?: number;
 }
 
-export interface ChatRequestMessage {
+export interface ChatRequestMessage extends WorkloadAttributionInput {
   jobID: string;
   type: 'llm';
   model: string;
@@ -295,6 +298,8 @@ export interface HostedToolExecutionParams {
   app_source?: string;
   /** camelCase alias for {@link HostedToolExecutionParams.app_source}. */
   appSource?: string;
+  /** Optional workload attribution overriding this client's defaults. */
+  attribution?: WorkloadAttributionInput;
   /** Token type to use for hosted REST billing. */
   token_type?: 'sogni' | 'spark' | 'auto';
   /** camelCase alias for {@link HostedToolExecutionParams.token_type}. */
@@ -457,6 +462,8 @@ export interface StartChatRunParams {
   billingMode?: BillingMode;
   /** Optional source label for attribution. Defaults to the client appSource when configured. */
   appSource?: string;
+  /** Optional workload attribution overriding this client's defaults. */
+  attribution?: WorkloadAttributionInput;
   /** Idempotency key (also accepted via `Idempotency-Key` header). */
   idempotencyKey?: string;
   /**
@@ -647,6 +654,8 @@ export interface ToolExecutionOptions {
   network?: 'fast' | 'relaxed';
   /** Number of media items to generate per tool call. Default: 1. */
   numberOfMedia?: number;
+  /** Optional workload attribution for media projects executed by the tool. */
+  attribution?: WorkloadAttributionInput;
   /** Progress callback fired during media generation. */
   onProgress?: (progress: ToolExecutionProgress) => void;
   /**

--- a/src/CreativeWorkflows/index.ts
+++ b/src/CreativeWorkflows/index.ts
@@ -16,6 +16,7 @@ import {
   StartCreativeWorkflowParams,
   StreamCreativeWorkflowEventsOptions
 } from './types.js';
+import getUUID from '../lib/getUUID.js';
 
 interface CreativeWorkflowEnvelope {
   workflow?: CreativeWorkflowRecord;
@@ -187,7 +188,8 @@ class CreativeWorkflowsApi extends ApiGroup {
     if (mediaReferences !== undefined) body.media_references = mediaReferences;
 
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...this.attributionHeaders(appSource, params.attribution, getUUID())
     };
     if (idempotencyKey) {
       headers['Idempotency-Key'] = idempotencyKey;
@@ -226,7 +228,10 @@ class CreativeWorkflowsApi extends ApiGroup {
       `/v1/creative-agent/workflows/${encodeURIComponent(workflowId)}/resume`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.attributionHeaders(appSource, params.attribution, getUUID())
+        },
         body: JSON.stringify(body),
         signal: options.signal
       }
@@ -261,7 +266,10 @@ class CreativeWorkflowsApi extends ApiGroup {
       `/v1/creative-agent/workflows/${encodeURIComponent(workflowId)}/reseed`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.attributionHeaders(appSource, params.attribution, getUUID())
+        },
         body: JSON.stringify(body),
         signal: options.signal
       }

--- a/src/CreativeWorkflows/types.ts
+++ b/src/CreativeWorkflows/types.ts
@@ -1,5 +1,6 @@
 import { TokenType } from '../types/token.js';
 import type { BillingMode } from '../Projects/types/index.js';
+import type { WorkloadAttributionInput } from '../types/attribution.js';
 
 export type CreativeWorkflowStatus =
   | 'queued'
@@ -144,6 +145,8 @@ export interface StartCreativeWorkflowParams {
   billingMode?: BillingMode;
   /** Optional source label for attribution. Defaults to the client appSource when configured. */
   appSource?: string;
+  /** Optional workload attribution overriding this client's defaults. */
+  attribution?: WorkloadAttributionInput;
   idempotencyKey?: string;
   /** Durable workflows require uploaded HTTP(S) URLs, not inline data URIs. */
   mediaReferences?: unknown[];
@@ -174,6 +177,8 @@ export interface ResumeCreativeWorkflowParams {
   billingMode?: BillingMode;
   /** Optional source label for attribution. Defaults to the client appSource when configured. */
   appSource?: string;
+  /** Optional workload attribution overriding this client's defaults. */
+  attribution?: WorkloadAttributionInput;
   /** @internal Undocumented compatibility alias. Use tokenType. */
   token_type?: TokenType;
   /** @internal Undocumented compatibility alias. Use billingMode. */
@@ -203,6 +208,8 @@ export interface ReseedCreativeWorkflowParams {
   billingMode?: BillingMode;
   /** Optional source label for attribution. Defaults to the client appSource when configured. */
   appSource?: string;
+  /** Optional workload attribution overriding this client's defaults. */
+  attribution?: WorkloadAttributionInput;
   /** @internal Undocumented compatibility alias. Use seedOverrides. */
   seed_overrides?: Record<string, number>;
   /** @internal Undocumented compatibility alias. Use tokenType. */

--- a/src/Projects/createJobRequestMessage.ts
+++ b/src/Projects/createJobRequestMessage.ts
@@ -43,6 +43,7 @@ import {
   ModelOptions,
   VideoModelOptions
 } from './types/ModelOptions.js';
+import { workloadAttributionToWireFields } from '../lib/attribution.js';
 
 /**
  * Validate that the provided assets match the workflow requirements.
@@ -735,7 +736,9 @@ function createJobRequestMessage(id: string, params: ProjectParams, options: Mod
     tokenType: params.tokenType,
     billingMode: params.billingMode,
     outputFormat:
-      params.outputFormat || (isAudioParams(params) ? 'mp3' : isVideoParams(params) ? 'mp4' : 'png')
+      params.outputFormat ||
+      (isAudioParams(params) ? 'mp3' : isVideoParams(params) ? 'mp4' : 'png'),
+    ...workloadAttributionToWireFields(params.attribution)
   };
 
   if (params.network) {

--- a/src/Projects/index.ts
+++ b/src/Projects/index.ts
@@ -667,7 +667,8 @@ class ProjectsApi extends ApiGroup<ProjectApiEvents> {
     const modelOptions = await this.getModelOptions(data.modelId);
     const requestParams = {
       ...data,
-      appSource: data.appSource || this.client.appSource
+      appSource: data.appSource || this.client.appSource,
+      attribution: this.resolveWorkloadAttribution(data.attribution, project.id)
     } as ProjectParams;
     const request = createJobRequestMessage(project.id, requestParams, modelOptions);
 

--- a/src/Projects/types/index.ts
+++ b/src/Projects/types/index.ts
@@ -1,6 +1,7 @@
 import { SupernetType } from '../../ApiClient/WebSocketClient/types.js';
 import { ControlNetParams, VideoControlNetParams } from './ControlNetParams.js';
 import { TokenType } from '../../types/token.js';
+import type { WorkloadAttributionInput } from '../../types/attribution.js';
 
 export interface SupportedModel {
   id: string;
@@ -99,6 +100,11 @@ export interface BaseProjectParams {
    * Optional client app/source label to attach to the project request for server-side attribution.
    */
   appSource?: string;
+  /**
+   * Optional workload attribution for this project. Fields override the
+   * immutable defaults configured on SogniClient.
+   */
+  attribution?: WorkloadAttributionInput;
   /**
    * LoRA IDs to apply, in the order they should be chained.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,20 @@ import {
   TokenAuthManager
 } from './lib/AuthManager/index.js';
 import { MeData } from './Account/types.js';
+import type {
+  AgentAttributionMetadata,
+  AgentSurface,
+  ConnectionAttribution,
+  ExecutionMode,
+  InteractionKind,
+  OperationLineage,
+  OperationScope,
+  SogniAttributionConfig,
+  WorkloadAttribution,
+  WorkloadAttributionDefaults,
+  WorkloadAttributionInput,
+  WorkloadKind
+} from './types/attribution.js';
 
 export type {
   AudioFormat,
@@ -313,7 +327,19 @@ export type {
   RawProject,
   ToastMessage,
   DataEntity,
-  InputMedia
+  InputMedia,
+  AgentAttributionMetadata,
+  AgentSurface,
+  ConnectionAttribution,
+  ExecutionMode,
+  InteractionKind,
+  OperationLineage,
+  OperationScope,
+  SogniAttributionConfig,
+  WorkloadAttribution,
+  WorkloadAttributionDefaults,
+  WorkloadAttributionInput,
+  WorkloadKind
 };
 
 export {
@@ -346,6 +372,13 @@ export interface SogniClientConfig {
    * The socket server uses this as the default source for project and chat requests from this client.
    */
   appSource?: string;
+  /**
+   * Optional immutable connection and per-workload attribution defaults.
+   *
+   * Individual project, chat, tool, and workflow calls can override workload
+   * fields without mutating other concurrent requests.
+   */
+  attribution?: SogniAttributionConfig;
   /**
    * Initial WebSocket event subscriptions for this connection.
    *
@@ -538,6 +571,7 @@ export class SogniClient {
       socketUrl: socketEndpoint,
       appId: config.appId,
       appSource: config.appSource,
+      attribution: config.attribution,
       socketEventSubscriptions: config.socketEventSubscriptions,
       networkType: network,
       logger,

--- a/src/lib/RestClient.ts
+++ b/src/lib/RestClient.ts
@@ -8,6 +8,11 @@ interface RestRequestInit extends RequestInit {
   timeoutMs?: number;
 }
 
+interface RestPostOptions {
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+}
+
 class RestClient<E extends EventMap = never> extends TypedEventEmitter<E> {
   readonly baseUrl: string;
   protected _auth: AuthManager;
@@ -120,15 +125,17 @@ class RestClient<E extends EventMap = never> extends TypedEventEmitter<E> {
   post<T = JSONValue>(
     path: string,
     body: Record<string, unknown> = {},
-    options: Pick<RestRequestInit, 'timeoutMs'> = {}
+    options: RestPostOptions = {}
   ): Promise<T> {
+    const { headers = {}, ...requestOptions } = options;
     return this.request<T>(this.formatUrl(path), {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...headers
       },
       body: JSON.stringify(body),
-      ...options
+      ...requestOptions
     });
   }
 }

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -1,0 +1,304 @@
+import type {
+  AgentAttributionMetadata,
+  AgentSurface,
+  ConnectionAttribution,
+  ExecutionMode,
+  InteractionKind,
+  OperationScope,
+  WorkloadAttributionDefaults,
+  WorkloadAttributionInput,
+  WorkloadKind
+} from '../types/attribution.js';
+
+const MAX_METADATA_LENGTH = 128;
+const MAX_VERSION_LENGTH = 32;
+const MAX_OPERATION_ID_LENGTH = 128;
+const UNSAFE_HEADER_CHARACTER = /[\u0000-\u001f\u007f]/;
+const VERSION_PATTERN = /^[0-9][0-9A-Za-z.+_-]*$/;
+const OPERATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
+const INTERACTION_KINDS = new Set<InteractionKind>([
+  'human_ui',
+  'external_agent',
+  'service',
+  'unknown'
+]);
+const WORKLOAD_KINDS = new Set<WorkloadKind>(['direct', 'agent_mediated', 'service', 'unknown']);
+const OPERATION_SCOPES = new Set<OperationScope>(['top_level', 'child', 'unknown']);
+const AGENT_SURFACES = new Set<AgentSurface>([
+  'native_web',
+  'native_mobile',
+  'native_desktop',
+  'plugin',
+  'personal_skill',
+  'mcp',
+  'cli',
+  'sdk',
+  'openai_compatible',
+  'direct_api',
+  'unknown'
+]);
+const EXECUTION_MODES = new Set<ExecutionMode>(['browser', 'durable', 'server', 'unknown']);
+
+export type NormalizedConnectionAttribution = Partial<ConnectionAttribution>;
+export type NormalizedWorkloadAttribution = WorkloadAttributionInput;
+
+function normalizeEnum<T extends string>(value: unknown, allowed: ReadonlySet<T>): T | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return allowed.has(normalized as T) ? (normalized as T) : undefined;
+}
+
+function normalizeBoundedString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  if (
+    normalized.length === 0 ||
+    normalized.length > maxLength ||
+    UNSAFE_HEADER_CHARACTER.test(normalized)
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function normalizeVersion(value: unknown): string | undefined {
+  const normalized = normalizeBoundedString(value, MAX_VERSION_LENGTH);
+  return normalized && VERSION_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+function normalizeOperationId(value: unknown): string | undefined {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_OPERATION_ID_LENGTH ||
+    value.trim() !== value ||
+    UNSAFE_HEADER_CHARACTER.test(value) ||
+    !OPERATION_ID_PATTERN.test(value)
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function normalizeAgentMetadata(
+  input: AgentAttributionMetadata | Record<string, unknown> | undefined
+): AgentAttributionMetadata {
+  if (!input || typeof input !== 'object') return {};
+  const result: AgentAttributionMetadata = {};
+  const agentFramework = normalizeBoundedString(input.agentFramework, MAX_METADATA_LENGTH);
+  const agentFrameworkVersion = normalizeVersion(input.agentFrameworkVersion);
+  const agentSurface = normalizeEnum(input.agentSurface, AGENT_SURFACES);
+  const agentSurfaceVersion = normalizeVersion(input.agentSurfaceVersion);
+  const executionMode = normalizeEnum(input.executionMode, EXECUTION_MODES);
+
+  if (agentFramework) result.agentFramework = agentFramework;
+  if (agentFrameworkVersion) result.agentFrameworkVersion = agentFrameworkVersion;
+  if (agentSurface) result.agentSurface = agentSurface;
+  if (agentSurfaceVersion) result.agentSurfaceVersion = agentSurfaceVersion;
+  if (executionMode) result.executionMode = executionMode;
+  return result;
+}
+
+function mergeDefined(defaults: object | undefined, overrides: object | undefined) {
+  const merged: Record<string, unknown> = { ...(defaults ?? {}) };
+  if (overrides && typeof overrides === 'object') {
+    const defaultValues = (defaults ?? {}) as Record<string, unknown>;
+    const overrideValues = overrides as Record<string, unknown>;
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value !== undefined) merged[key] = value;
+    }
+    // A version belongs to its framework/surface. Do not accidentally retain
+    // one default's version when a request changes the corresponding identity.
+    if (
+      overrideValues.agentFramework !== undefined &&
+      overrideValues.agentFramework !== defaultValues.agentFramework &&
+      overrideValues.agentFrameworkVersion === undefined
+    ) {
+      delete merged.agentFrameworkVersion;
+    }
+    if (
+      overrideValues.agentSurface !== undefined &&
+      overrideValues.agentSurface !== defaultValues.agentSurface &&
+      overrideValues.agentSurfaceVersion === undefined
+    ) {
+      delete merged.agentSurfaceVersion;
+    }
+  }
+  return merged;
+}
+
+function hasValues(value: object): boolean {
+  return Object.keys(value).length > 0;
+}
+
+export function normalizeConnectionAttribution(
+  input: ConnectionAttribution | Partial<ConnectionAttribution> | undefined
+): NormalizedConnectionAttribution | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  const result: NormalizedConnectionAttribution = normalizeAgentMetadata(input);
+  const interactionKind = normalizeEnum(
+    (input as unknown as Record<string, unknown>).interactionKind,
+    INTERACTION_KINDS
+  );
+  if (interactionKind) result.interactionKind = interactionKind;
+  return hasValues(result) ? result : undefined;
+}
+
+/**
+ * Merge immutable client defaults with one operation's overrides and add
+ * lineage derived from the underlying request ID. Invalid runtime values are
+ * dropped instead of rejecting an otherwise valid inference request.
+ */
+export function resolveWorkloadAttribution(
+  defaults: WorkloadAttributionDefaults | undefined,
+  overrides: WorkloadAttributionInput | undefined,
+  fallbackOperationId?: string
+): NormalizedWorkloadAttribution | undefined {
+  if (!defaults && !overrides) return undefined;
+
+  const merged = mergeDefined(defaults, overrides);
+  const result: NormalizedWorkloadAttribution = normalizeAgentMetadata(merged);
+  const workloadKind = normalizeEnum(merged.workloadKind, WORKLOAD_KINDS);
+  const operationScope = normalizeEnum(merged.operationScope, OPERATION_SCOPES);
+  const operationId = normalizeOperationId(merged.operationId);
+  const rootOperationId = normalizeOperationId(merged.rootOperationId);
+  const parentOperationId = normalizeOperationId(merged.parentOperationId);
+
+  if (workloadKind) result.workloadKind = workloadKind;
+  if (operationScope) result.operationScope = operationScope;
+  if (operationId) result.operationId = operationId;
+  if (rootOperationId) result.rootOperationId = rootOperationId;
+  if (parentOperationId) result.parentOperationId = parentOperationId;
+
+  if (result.workloadKind && result.workloadKind !== 'agent_mediated') {
+    delete result.agentFramework;
+    delete result.agentFrameworkVersion;
+  }
+
+  // Do not turn an empty/invalid attribution object into attributed traffic
+  // solely because the transport happens to have a request ID.
+  if (!hasValues(result)) return undefined;
+
+  if (!result.operationId) {
+    const fallback = normalizeOperationId(fallbackOperationId);
+    if (fallback) result.operationId = fallback;
+  }
+
+  if (result.operationId && !result.operationScope) {
+    result.operationScope =
+      result.parentOperationId ||
+      (result.rootOperationId && result.rootOperationId !== result.operationId)
+        ? 'child'
+        : 'top_level';
+  }
+
+  if (result.operationScope === 'child' && result.rootOperationId && !result.parentOperationId) {
+    result.parentOperationId = result.rootOperationId;
+  }
+
+  if (result.operationScope === 'top_level' && result.operationId) {
+    result.rootOperationId = result.operationId;
+    delete result.parentOperationId;
+  }
+
+  return result;
+}
+
+/** Add flat camelCase connection attribution fields to a WebSocket URL. */
+export function appendConnectionAttributionQuery(
+  url: URL,
+  attribution: NormalizedConnectionAttribution | undefined
+): void {
+  if (!attribution) return;
+  const fields: Array<keyof NormalizedConnectionAttribution> = [
+    'interactionKind',
+    'agentFramework',
+    'agentFrameworkVersion',
+    'agentSurface',
+    'agentSurfaceVersion',
+    'executionMode'
+  ];
+  for (const field of fields) {
+    const value = attribution[field];
+    if (typeof value === 'string') url.searchParams.set(field, value);
+  }
+}
+
+/** Return flat camelCase workload fields for socket request payloads. */
+export function workloadAttributionToWireFields(
+  attribution: NormalizedWorkloadAttribution | undefined
+): Record<string, string> {
+  if (!attribution) return {};
+  const result: Record<string, string> = {};
+  for (const field of [
+    'workloadKind',
+    'agentFramework',
+    'agentFrameworkVersion',
+    'agentSurface',
+    'agentSurfaceVersion',
+    'executionMode',
+    'operationScope',
+    'operationId',
+    'rootOperationId',
+    'parentOperationId'
+  ] as const) {
+    const value = attribution[field];
+    if (typeof value === 'string') result[field] = value;
+  }
+  return result;
+}
+
+export interface SogniAttributionHeaderInput {
+  appSource?: string;
+  connection?: NormalizedConnectionAttribution;
+  workload?: NormalizedWorkloadAttribution;
+}
+
+/**
+ * Build headers only for requests whose caller has already established that
+ * the destination is a Sogni-owned endpoint.
+ */
+export function buildSogniAttributionHeaders({
+  appSource,
+  connection,
+  workload
+}: SogniAttributionHeaderInput): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const normalizedAppSource = normalizeBoundedString(appSource, MAX_METADATA_LENGTH);
+  if (normalizedAppSource) headers['X-App-Source'] = normalizedAppSource;
+  if (connection?.interactionKind) {
+    headers['X-Sogni-Interaction-Kind'] = connection.interactionKind;
+  }
+  if (workload?.workloadKind) {
+    headers['X-Sogni-Workload-Kind'] = workload.workloadKind;
+  }
+  if (workload?.agentFramework) {
+    headers['X-Sogni-Agent-Framework'] = workload.agentFramework;
+  }
+  if (workload?.agentFrameworkVersion) {
+    headers['X-Sogni-Agent-Framework-Version'] = workload.agentFrameworkVersion;
+  }
+  if (workload?.agentSurface) {
+    headers['X-Sogni-Agent-Surface'] = workload.agentSurface;
+  }
+  if (workload?.agentSurfaceVersion) {
+    headers['X-Sogni-Agent-Surface-Version'] = workload.agentSurfaceVersion;
+  }
+  if (workload?.executionMode) {
+    headers['X-Sogni-Execution-Mode'] = workload.executionMode;
+  }
+  if (workload?.operationScope) {
+    headers['X-Sogni-Operation-Scope'] = workload.operationScope;
+  }
+  if (workload?.operationId) {
+    headers['X-Sogni-Operation-Id'] = workload.operationId;
+  }
+  if (workload?.rootOperationId) {
+    headers['X-Sogni-Root-Operation-Id'] = workload.rootOperationId;
+  }
+  if (workload?.parentOperationId) {
+    headers['X-Sogni-Parent-Operation-Id'] = workload.parentOperationId;
+  }
+  return headers;
+}

--- a/src/types/attribution.ts
+++ b/src/types/attribution.ts
@@ -1,0 +1,89 @@
+/**
+ * How a caller is interacting with Sogni at the connection boundary.
+ *
+ * Connection attribution and workload attribution are intentionally separate:
+ * a human-facing application can issue both direct and agent-mediated work on
+ * the same connection.
+ */
+export type InteractionKind = 'human_ui' | 'external_agent' | 'service' | 'unknown';
+
+/** How a logical Sogni workload was initiated. */
+export type WorkloadKind = 'direct' | 'agent_mediated' | 'service' | 'unknown';
+
+/** Whether an operation is a user-visible root or work performed on its behalf. */
+export type OperationScope = 'top_level' | 'child' | 'unknown';
+
+/** The integration surface used to reach Sogni. */
+export type AgentSurface =
+  | 'native_web'
+  | 'native_mobile'
+  | 'native_desktop'
+  | 'plugin'
+  | 'personal_skill'
+  | 'mcp'
+  | 'cli'
+  | 'sdk'
+  | 'openai_compatible'
+  | 'direct_api'
+  | 'unknown';
+
+/** Optional execution detail for agent-mediated products. */
+export type ExecutionMode = 'browser' | 'durable' | 'server' | 'unknown';
+
+/** Agent metadata shared by connection and workload attribution. */
+export interface AgentAttributionMetadata {
+  /** Canonical agent host, for example `codex`, `claude-code`, or `sogni-chat`. */
+  agentFramework?: string;
+  /** Version of the agent host when known. */
+  agentFrameworkVersion?: string;
+  /** How the agent host integrated with Sogni. */
+  agentSurface?: AgentSurface;
+  /** Version of the integration surface when known. */
+  agentSurfaceVersion?: string;
+  /** Product execution detail, such as browser or durable execution. */
+  executionMode?: ExecutionMode;
+}
+
+/** Attribution captured when the SDK opens a Sogni WebSocket connection. */
+export interface ConnectionAttribution extends AgentAttributionMetadata {
+  interactionKind: InteractionKind;
+}
+
+/**
+ * Defaults applied independently to each attributed workload.
+ *
+ * Operation IDs do not belong in client-wide defaults because concurrent
+ * requests must never share mutable lineage state.
+ */
+export interface WorkloadAttributionDefaults extends AgentAttributionMetadata {
+  workloadKind: WorkloadKind;
+}
+
+/** Opaque identifiers that relate a request to its logical parent and root. */
+export interface OperationLineage {
+  operationScope: OperationScope;
+  operationId: string;
+  rootOperationId: string;
+  parentOperationId?: string;
+}
+
+/**
+ * Per-operation attribution input.
+ *
+ * Every property is optional so a request can override only one client
+ * default. When attribution is present, the SDK supplies an operation ID from
+ * the underlying project/job request when one is not provided.
+ */
+export interface WorkloadAttributionInput
+  extends Partial<WorkloadAttributionDefaults>, Partial<OperationLineage> {}
+
+/** Fully classified workload attribution after server normalization. */
+export interface WorkloadAttribution extends AgentAttributionMetadata, OperationLineage {
+  workloadKind: WorkloadKind;
+}
+
+/** Immutable attribution defaults configured when creating a client. */
+export interface SogniAttributionConfig {
+  connection?: ConnectionAttribution;
+  workload?: WorkloadAttributionDefaults;
+}


### PR DESCRIPTION
## What changed

- adds immutable connection attribution and per-operation workload attribution to `SogniClient`
- carries flat, bounded metadata over WebSocket connection/query fields, media and LLM payloads, and owned hosted REST headers
- models top-level versus child operation lineage so agent request share is not inflated by internal tool, LLM, workflow, or media calls
- supports per-call overrides, including direct/manual overrides that clear inherited framework identity
- keeps legacy callers unattributed and leaves presigned storage requests untouched
- documents the public contract and adds an attribution transport release gate

## Why

The Agents dashboard needs a privacy-safe way to distinguish human UI connections from external agents, and direct requests from agent-mediated workloads. Framework and lineage metadata must originate at the integration boundary so the server can aggregate Codex, Claude Code/Desktop, OpenClaw, Hermes, Sogni Chat, and future native agents without inspecting prompts or user content.

## Impact

This is additive and backward compatible. Existing clients emit no new semantic attribution unless configured. Invalid or oversized metadata is dropped, attribution defaults are immutable, and concurrent operations do not share mutable lineage state.

This PR is the first package in a coordinated rollout. Downstream consumers will pin the released SDK version only after this PR's semantic release completes.

## Validation

- `npm run test:attribution`
- `npm run test:chat-routing`
- `npm run test:subscription-api`
- `npm run test:workflow-template-envelope`
- `npm run build`
- `npm run prettier`
- `git diff --check`
