### PR TITLE
fix(projects): allow sparse audio model tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sogni-ai/sogni-client",
-  "version": "5.13.0",
+  "version": "5.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sogni-ai/sogni-client",
-      "version": "5.13.0",
+      "version": "5.15.1",
       "license": "ISC",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",

--- a/scripts/check-video-model-options.cjs
+++ b/scripts/check-video-model-options.cjs
@@ -1,5 +1,5 @@
 /**
- * Regression checks for server-advertised video model geometry.
+ * Regression checks for server-advertised model options.
  * Runs against compiled `dist/` output to verify the public SDK mapping.
  */
 
@@ -14,6 +14,8 @@ const VIDEO_MODEL_ID = 'minimax-h3-fl2va-fp8_t2v';
 const VIDEO_TIER_ID = 'minimax-h3-fl2va-fp8_t2v';
 const UPSCALE_MODEL_ID = 'rtx_vsr_pro';
 const UPSCALE_TIER_ID = 'rtx_vsr_pro';
+const MUSIC_MODEL_ID = 'minimax_music3';
+const MUSIC_TIER_ID = 'minimax_music3';
 const SILENT_LOGGER = { info() {}, warn() {}, error() {}, debug() {} };
 
 class SocketStub extends EventEmitter {
@@ -21,7 +23,8 @@ class SocketStub extends EventEmitter {
     if (path === '/api/v1/models/list') {
       return [
         { id: VIDEO_MODEL_ID, name: 'MiniMax H3 T2V', SID: 1, tier: VIDEO_TIER_ID, media: 'video' },
-        { id: UPSCALE_MODEL_ID, name: 'RTX VSR Pro', SID: 2, tier: UPSCALE_TIER_ID, media: 'image' }
+        { id: UPSCALE_MODEL_ID, name: 'RTX VSR Pro', SID: 2, tier: UPSCALE_TIER_ID, media: 'image' },
+        { id: MUSIC_MODEL_ID, name: 'MiniMax Music 3', SID: 3, tier: MUSIC_TIER_ID, media: 'audio' }
       ];
     }
     if (path === '/api/v2/models/tiers') {
@@ -41,6 +44,15 @@ class SocketStub extends EventEmitter {
           defaultSize: 2048,
           steps: { min: 1, max: 1, default: 1 },
           comfyScheduler: { allowed: [], default: '' }
+        },
+        [MUSIC_TIER_ID]: {
+          type: 'audio',
+          benchmark: { sec: 1, secCN: 0, secMaxPreviews: 0 },
+          steps: { min: 10, max: 100, default: 30 },
+          guidance: { min: 1, max: 5, decimals: 1, default: 1.7 },
+          duration: { min: 10, max: 300, default: 60 },
+          comfySampler: { allowed: ['euler'], default: 'euler' },
+          comfyScheduler: { allowed: ['simple'], default: 'simple' }
         }
       };
     }
@@ -73,6 +85,16 @@ async function main() {
   assert.equal(Object.hasOwn(upscaleOptions, 'guidance'), false);
   assert.deepEqual(upscaleOptions.sampler, { allowed: [], default: null });
   assert.deepEqual(upscaleOptions.scheduler, { allowed: [], default: '' });
+
+  const musicOptions = await projects.getModelOptions(MUSIC_MODEL_ID);
+
+  assert.equal(musicOptions.type, 'audio');
+  assert.deepEqual(musicOptions.steps, { min: 10, max: 100, step: 1, default: 30 });
+  assert.deepEqual(musicOptions.guidance, { min: 1, max: 5, step: 0.1, default: 1.7 });
+  assert.deepEqual(musicOptions.duration, { min: 10, max: 300, step: 1, default: 60 });
+  assert.equal(Object.hasOwn(musicOptions, 'bpm'), false);
+  assert.equal(Object.hasOwn(musicOptions, 'timesignature'), false);
+  assert.equal(Object.hasOwn(musicOptions, 'language'), false);
 
   console.log('Model option checks passed');
 }

--- a/src/Projects/types/ModelOptions.ts
+++ b/src/Projects/types/ModelOptions.ts
@@ -56,9 +56,9 @@ export interface AudioModelOptions {
   sampler: Options<string>;
   scheduler: Options<string>;
   duration: NumRange;
-  bpm: NumRange;
-  timesignature: Options<string>;
-  language: Options<string>;
+  bpm?: NumRange;
+  timesignature?: Options<string>;
+  language?: Options<string>;
   keyscale?: Options<string>;
   composerMode?: { default: boolean };
   promptStrength?: NumRange;
@@ -143,13 +143,19 @@ export function mapAudioTier(tier: AudioTier): AudioModelOptions {
     steps: mapRange(tier.steps),
     sampler: mapOptions(tier.comfySampler, samplerValueToAlias),
     scheduler: mapOptions(tier.comfyScheduler, schedulerValueToAlias),
-    duration: mapRange(tier.duration),
-    bpm: mapRange(tier.bpm),
-    timesignature: mapOptions(tier.timesignature),
-    language: mapOptions(tier.language)
+    duration: mapRange(tier.duration)
   };
   if (tier.guidance) {
     options.guidance = mapRange(tier.guidance);
+  }
+  if (tier.bpm) {
+    options.bpm = mapRange(tier.bpm);
+  }
+  if (tier.timesignature) {
+    options.timesignature = mapOptions(tier.timesignature);
+  }
+  if (tier.language) {
+    options.language = mapOptions(tier.language);
   }
   if (tier.keyscale) {
     options.keyscale = mapOptions(tier.keyscale);

--- a/src/Projects/types/ModelTiersRaw.ts
+++ b/src/Projects/types/ModelTiersRaw.ts
@@ -91,7 +91,7 @@ export interface BooleanDefault {
 
 export interface AudioTier {
   benchmark: Benchmark;
-  bpm: NumericDefaults;
+  bpm?: NumericDefaults;
   comfySampler: StringDefaults;
   comfyScheduler: StringDefaults;
   composerMode?: BooleanDefault;
@@ -99,11 +99,11 @@ export interface AudioTier {
   duration: NumericDefaults;
   guidance?: NumericDefaults;
   keyscale?: StringDefaults;
-  language: StringDefaults;
+  language?: StringDefaults;
   promptStrength?: NumericDefaults;
   shift?: NumericDefaults;
   steps: NumericDefaults;
-  timesignature: StringDefaults;
+  timesignature?: StringDefaults;
   type: 'audio';
 }
 


### PR DESCRIPTION
## Summary

- make BPM, time signature, and language optional in server-advertised audio tiers
- omit unsupported controls when mapping MiniMax Music 3 options
- add a regression covering the sparse MiniMax Music 3 tier beside RTX VSR

## Validation

- `npm run build`
- model-option, chat-routing, attribution, subscription, liveness, timeout, queue, and workflow checks
- `npm audit signatures`
- `npm pack --dry-run`

Formatting note: the repository-wide Prettier check still reports the two pre-existing files `src/Account/index.ts` and `src/Projects/index.ts`; neither is changed by this PR.
