### PR TITLE
fix(workflows): serialize the content filter preference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
         run: npm run test:model-options
       - name: Run attribution transport checks
         run: npm run test:attribution
+      - name: Run workflow content filter checks
+        run: node scripts/check-workflow-content-filter.cjs
       - name: Run REST-only client checks
         run: npm run test:rest-only
       - name: Run project cancellation checks

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test:project-recovery": "npm run build && node scripts/check-project-recovery.cjs",
     "test:queue-wait-eta": "npm run build && node scripts/check-queue-wait-eta.cjs",
     "test:workflow-template-envelope": "npm run build && node scripts/check-workflow-template-envelope.cjs",
+    "test:workflow-content-filter": "npm run build && node scripts/check-workflow-content-filter.cjs",
     "watch": "npm run clean && npm run codegen && tsc --watch --project tsconfig.json",
     "watch:esm": "npm run codegen && tsc --watch --project tsconfig.esm.json",
     "prettier": "prettier --check ./src",

--- a/scripts/check-workflow-content-filter.cjs
+++ b/scripts/check-workflow-content-filter.cjs
@@ -1,0 +1,60 @@
+const assert = require('node:assert/strict');
+const CreativeWorkflowsApi = require('../dist/CreativeWorkflows/index.js').default;
+
+const api = new CreativeWorkflowsApi({
+  client: {
+    auth: { authenticateRequest: async (init) => init },
+    rest: { baseUrl: 'https://api.example.test' }
+  },
+  eip712: {}
+});
+const realFetch = globalThis.fetch;
+let lastRequest;
+globalThis.fetch = async (url, init) => {
+  lastRequest = { url: String(url), method: init.method, body: JSON.parse(init.body) };
+  return new Response(JSON.stringify({
+    status: 'success',
+    data: { workflow: { workflowId: 'wf_test', safeContentFilter: false } }
+  }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+};
+
+async function run() {
+  const plans = [
+    { workflowId: 'wf_template', inputs: { brief: 'A ceramic vase' } },
+    { input: { steps: [{ toolName: 'generate_image', arguments: { prompt: 'A ceramic vase' } }] } }
+  ];
+  for (const plan of plans) {
+    for (const preference of [true, false, undefined]) {
+      const result = await api.start({ ...plan, safeContentFilter: preference });
+      assert.equal(lastRequest.method, 'POST');
+      assert.equal(lastRequest.url, 'https://api.example.test/v1/creative-agent/workflows');
+      assert.equal(lastRequest.body.safe_content_filter, preference);
+      assert.equal(Object.hasOwn(lastRequest.body, 'safe_content_filter'), preference !== undefined);
+      assert.equal(Object.hasOwn(lastRequest.body, 'safeContentFilter'), false);
+      assert.equal(result.safeContentFilter, false, 'response preserves the stored preference');
+    }
+  }
+  await api.start({ workflowId: 'wf_template', safe_content_filter: false });
+  assert.equal(lastRequest.body.safe_content_filter, false, 'snake-case alias preserves false');
+  for (const preference of [true, false]) {
+    await api.start({
+      workflowId: 'wf_template',
+      safeContentFilter: preference,
+      safe_content_filter: !preference
+    });
+    assert.equal(lastRequest.body.safe_content_filter, preference, 'camel-case option takes precedence');
+  }
+  await api.start({ workflowId: 'wf_template', inputs: { safe_content_filter: false } });
+  assert.equal(Object.hasOwn(lastRequest.body, 'safe_content_filter'), false, 'template input stays nested');
+
+  for (const action of ['resume', 'reseed']) {
+    await api[action]('wf_test', { safeContentFilter: true, safe_content_filter: true });
+    assert.equal(Object.hasOwn(lastRequest.body, 'safe_content_filter'), false, `${action} cannot replace the saved preference`);
+  }
+  console.log('Workflow content filter transport checks passed.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+}).finally(() => { globalThis.fetch = realFetch; });

--- a/src/CreativeWorkflows/index.ts
+++ b/src/CreativeWorkflows/index.ts
@@ -161,6 +161,7 @@ class CreativeWorkflowsApi extends ApiGroup {
     const maxEstimatedCapacityUnits =
       params.maxEstimatedCapacityUnits ?? params.max_estimated_capacity_units;
     const confirmCost = params.confirmCost ?? params.confirm_cost;
+    const safeContentFilter = params.safeContentFilter ?? params.safe_content_filter;
     const workflowId = params.workflowId ?? params.workflow_id;
 
     if (!params.input && !workflowId) {
@@ -185,6 +186,7 @@ class CreativeWorkflowsApi extends ApiGroup {
       body.max_estimated_capacity_units = maxEstimatedCapacityUnits;
     }
     if (confirmCost !== undefined) body.confirm_cost = confirmCost;
+    if (safeContentFilter !== undefined) body.safe_content_filter = safeContentFilter;
     if (mediaReferences !== undefined) body.media_references = mediaReferences;
 
     const headers: Record<string, string> = {

--- a/src/CreativeWorkflows/types.ts
+++ b/src/CreativeWorkflows/types.ts
@@ -78,6 +78,8 @@ export interface CreativeWorkflowEvent {
 
 export interface CreativeWorkflowRecord {
   workflowId: string;
+  /** Safe Content Filter preference captured when the run started. Defaults to true. */
+  safeContentFilter?: boolean;
   title?: string;
   status?: CreativeWorkflowStatus;
   /** Why a `waiting_for_user` workflow is paused. */
@@ -167,6 +169,11 @@ export interface StartCreativeWorkflowParams {
   mediaReferences?: unknown[];
   maxEstimatedCapacityUnits?: number;
   confirmCost?: boolean;
+  /**
+   * Safe Content Filter preference for this run. Defaults to true.
+   * Resuming or reseeding a run preserves its original preference.
+   */
+  safeContentFilter?: boolean;
   /** @internal Undocumented compatibility alias. Use workflowId. */
   workflow_id?: string;
   /** @internal Undocumented compatibility alias. Use tokenType. */
@@ -183,6 +190,8 @@ export interface StartCreativeWorkflowParams {
   max_estimated_capacity_units?: number;
   /** @internal Undocumented compatibility alias. Use confirmCost. */
   confirm_cost?: boolean;
+  /** @internal Undocumented compatibility alias. Use safeContentFilter. */
+  safe_content_filter?: boolean;
 }
 
 export interface ResumeCreativeWorkflowParams {


### PR DESCRIPTION
Workflow start requests currently omit the Safe Content Filter preference. Add the optional `safeContentFilter` start option and record field, serialize explicit `true` and `false` as `safe_content_filter`, and retain omission when the caller supplies no preference.

The HTTP regression covers inline and saved workflows, the snake-case compatibility alias, conflicting aliases, response records, and resume/reseed request behavior. It runs in the SDK release checks.

Validation: CJS and ESM builds; `check-workflow-content-filter.cjs`; `check-workflow-template-envelope.cjs`.
